### PR TITLE
Feat/busola/editorial access manager

### DIFF
--- a/css/factsheet-team.css
+++ b/css/factsheet-team.css
@@ -1,0 +1,377 @@
+/* =================================================================
+   Editorial Access Manager – Factsheet Team meta box
+   A polished, modern UI that fits within WordPress admin.
+   Custom multi-select (no external JS).
+   ================================================================= */
+
+#gsdp-eam-wrap {
+	padding: 4px 0 0;
+}
+
+/* Hide native multi-selects until JS replaces them (avoids flash of unstyled/native control) */
+#gsdp_team_roles,
+#gsdp_team_members {
+	position: absolute !important;
+	left: -9999px !important;
+	width: 1px !important;
+	height: 1px !important;
+	clip: rect(0, 0, 0, 0);
+	opacity: 0;
+	pointer-events: none;
+}
+
+
+/* Loader shown until custom widget is built */
+.gsdp-multiselect-loader {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 12px;
+	min-height: 42px;
+	background: #f6f7f7;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	color: #50575e;
+	font-size: 13px;
+}
+
+.gsdp-multiselect-loader-spinner {
+	display: inline-block;
+	width: 18px;
+	height: 18px;
+	border: 2px solid #c3c4c7;
+	border-top-color: #2271b1;
+	border-radius: 50%;
+	animation: gsdp-spin 0.7s linear infinite;
+}
+
+.gsdp-multiselect-loader-text {
+	opacity: 0.85;
+}
+
+@keyframes gsdp-spin {
+	to { transform: rotate(360deg); }
+}
+
+/* -----------------------------------------------------------------
+   Status badge
+   ----------------------------------------------------------------- */
+
+.gsdp-eam-status {
+	margin-bottom: 12px;
+}
+
+.gsdp-eam-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 10px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1.4;
+}
+
+.gsdp-eam-badge .dashicons {
+	font-size: 14px;
+	width: 14px;
+	height: 14px;
+	line-height: 14px;
+}
+
+.gsdp-eam-badge--off {
+	background: #f0f0f1;
+	color: #787c82;
+}
+
+.gsdp-eam-badge--active {
+	background: #e6f2e8;
+	color: #1e7e34;
+}
+
+/* -----------------------------------------------------------------
+   Segmented-control mode selector
+   ----------------------------------------------------------------- */
+
+.gsdp-eam-modes {
+	display: flex;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	overflow: hidden;
+	margin-bottom: 14px;
+}
+
+.gsdp-eam-mode-btn {
+	flex: 1;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 3px;
+	padding: 7px 4px;
+	margin: 0;
+	background: #f6f7f7;
+	border: none;
+	border-right: 1px solid #c3c4c7;
+	color: #50575e;
+	font-size: 12px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background 0.15s, color 0.15s;
+	line-height: 1;
+}
+
+.gsdp-eam-mode-btn:last-child {
+	border-right: none;
+}
+
+.gsdp-eam-mode-btn:hover {
+	background: #e8eaed;
+	color: #1d2327;
+}
+
+.gsdp-eam-mode-btn.active {
+	background: #2271b1;
+	color: #fff;
+}
+
+.gsdp-eam-mode-btn .dashicons {
+	font-size: 15px;
+	width: 15px;
+	height: 15px;
+	line-height: 15px;
+}
+
+/* -----------------------------------------------------------------
+   Tabs
+   ----------------------------------------------------------------- */
+
+#gsdp-eam-tabs {
+	display: flex;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	border-bottom: 1px solid #c3c4c7;
+}
+
+#gsdp-eam-tabs li {
+	margin: 0;
+}
+
+#gsdp-eam-tabs li a {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 12px;
+	color: #50575e;
+	text-decoration: none;
+	font-size: 13px;
+	font-weight: 500;
+	border-bottom: 2px solid transparent;
+	transition: color 0.15s, border-color 0.15s;
+	cursor: pointer;
+}
+
+#gsdp-eam-tabs li a:hover {
+	color: #2271b1;
+}
+
+#gsdp-eam-tabs li.active a {
+	color: #2271b1;
+	border-bottom-color: #2271b1;
+	font-weight: 600;
+}
+
+.gsdp-eam-count {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 18px;
+	height: 18px;
+	padding: 0 5px;
+	border-radius: 9px;
+	background: #dcdcde;
+	color: #50575e;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1;
+}
+
+#gsdp-eam-tabs li.active .gsdp-eam-count {
+	background: #2271b1;
+	color: #fff;
+}
+
+/* -----------------------------------------------------------------
+   Tab panels
+   ----------------------------------------------------------------- */
+
+#gsdp-eam-panels {
+	border: 1px solid #c3c4c7;
+	border-radius: 0 0 4px 4px;
+	border-top: none;
+	background: #fff;
+}
+
+.gsdp-eam-tab-panel {
+	padding: 10px;
+}
+
+/* -----------------------------------------------------------------
+   Custom multi-select widget (Chosen-like UI, no Chosen dependency)
+   ----------------------------------------------------------------- */
+
+.gsdp-multiselect {
+	position: relative;
+	display: block;
+	width: 100%;
+	font-size: 13px;
+	box-sizing: border-box;
+}
+
+.gsdp-multiselect-inner {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 4px;
+	min-height: 34px;
+	padding: 4px 6px;
+	border: 1px solid #c3c4c7;
+	border-radius: 3px;
+	background: #fff;
+	cursor: text;
+}
+
+.gsdp-multiselect.is-open .gsdp-multiselect-inner {
+	border-color: #2271b1;
+	box-shadow: 0 0 0 1px #2271b1;
+}
+
+.gsdp-multiselect-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	align-items: center;
+}
+
+.gsdp-multiselect-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 8px;
+	border: 1px solid #c3c4c7;
+	border-radius: 3px;
+	background: #f0f0f1;
+	color: #1d2327;
+	font-size: 12px;
+	line-height: 1.3;
+}
+
+.gsdp-multiselect-chip.is-disabled {
+	background: #e8eaed;
+	color: #50575e;
+	padding-right: 8px;
+}
+
+.gsdp-multiselect-chip-remove {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	margin: 0;
+	margin-left: 2px;
+	width: 16px;
+	height: 16px;
+	border: none;
+	background: none;
+	color: #787c82;
+	font-size: 16px;
+	line-height: 1;
+	cursor: pointer;
+	border-radius: 2px;
+}
+
+.gsdp-multiselect-chip-remove:hover {
+	color: #d63638;
+	background: rgba(0, 0, 0, 0.05);
+}
+
+.gsdp-multiselect-search-wrap {
+	flex: 1;
+	min-width: 80px;
+}
+
+.gsdp-multiselect-search {
+	width: 100%;
+	min-width: 80px;
+	padding: 4px 6px;
+	margin: 0;
+	border: none;
+	background: transparent;
+	font-size: 13px;
+	color: #1d2327;
+	outline: none;
+	box-sizing: border-box;
+}
+
+.gsdp-multiselect-search::placeholder {
+	color: #787c82;
+}
+
+.gsdp-multiselect-dropdown {
+	display: none;
+	position: absolute;
+	top: 100%;
+	left: 0;
+	right: 0;
+	z-index: 1010;
+	margin-top: -1px;
+	border: 1px solid #c3c4c7;
+	border-top: none;
+	border-radius: 0 0 3px 3px;
+	background: #fff;
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+	max-height: 200px;
+	overflow: hidden;
+}
+
+.gsdp-multiselect.is-open .gsdp-multiselect-dropdown {
+	display: block;
+}
+
+.gsdp-multiselect-results {
+	margin: 0;
+	padding: 4px 0;
+	list-style: none;
+	max-height: 200px;
+	overflow-y: auto;
+}
+
+.gsdp-multiselect-results li {
+	margin: 0;
+	padding: 6px 10px;
+	font-size: 13px;
+	line-height: 1.4;
+	cursor: pointer;
+}
+
+.gsdp-multiselect-results li[data-value]:hover {
+	background: #f0f0f1;
+}
+
+.gsdp-multiselect-results li.is-selected {
+	background: #e5f5fa;
+	color: #1d2327;
+}
+
+.gsdp-multiselect-results li.is-disabled {
+	color: #787c82;
+	cursor: default;
+}
+
+.gsdp-multiselect-no-results {
+	padding: 8px 10px !important;
+	color: #787c82;
+	font-style: italic;
+	cursor: default !important;
+	background: #f6f7f7 !important;
+}

--- a/includes/factsheet-team.php
+++ b/includes/factsheet-team.php
@@ -1,0 +1,531 @@
+<?php
+
+namespace WSUWP\Plugin\Graduate;
+
+/**
+ * Manages team member assignment for factsheets.
+ *
+ * Replaces the dependency on the Editorial Access Manager (EAM) plugin
+ * for controlling which users can edit specific factsheets. The UI
+ * uses an Off / Roles / Users mode selector and a WordPress-style
+ * tabbed panel (matching the Program Names taxonomy box) with Chosen.js
+ * multi-selects for roles and users.
+ *
+ * @since 1.3.0
+ */
+class Factsheet_Team {
+
+	const META_KEY_MODE    = 'gsdp_team_access_mode';
+	const META_KEY_ROLES   = 'gsdp_team_roles';
+	const META_KEY_MEMBERS = 'gsdp_team_members';
+	const NONCE_ACTION     = 'gsdp_save_team';
+	const NONCE_NAME       = '_gsdp_team_nonce';
+	const POST_TYPE        = 'gs-factsheet';
+
+	public static function init() {
+		add_action( 'add_meta_boxes', array( __CLASS__, 'add_meta_box' ) );
+		add_action( 'save_post_' . self::POST_TYPE, array( __CLASS__, 'save_team_members' ), 10, 2 );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+
+		add_filter( 'eam_post_types', array( __CLASS__, 'exclude_from_eam' ) );
+
+		add_filter( 'map_meta_cap', array( __CLASS__, 'map_meta_cap' ), 150, 4 );
+	}
+
+	/**
+	 * Remove factsheets from EAM's managed post types.
+	 *
+	 * @param array $post_types Post types managed by EAM.
+	 * @return array
+	 */
+	public static function exclude_from_eam( $post_types ) {
+		unset( $post_types[ self::POST_TYPE ] );
+		return $post_types;
+	}
+
+	// ------------------------------------------------------------------
+	// Meta box
+	// ------------------------------------------------------------------
+
+	public static function add_meta_box() {
+		\add_meta_box(
+			'gsdp-team-members',
+			__( 'Editorial Access Manager', 'wsuwp-plugin-graduate-school' ),
+			array( __CLASS__, 'render_meta_box' ),
+			self::POST_TYPE,
+			'side',
+			'default'
+		);
+	}
+
+	/**
+	 * Render the meta box.
+	 *
+	 * Layout:
+	 *   1. Status badge showing current access state
+	 *   2. Segmented-control mode selector (Off / Roles / Users)
+	 *   3. Tabbed panel with Chosen.js multi-selects
+	 *
+	 * @param \WP_Post $post Current post object.
+	 */
+	public static function render_meta_box( $post ) {
+		global $wp_roles;
+
+		$mode            = self::get_access_mode( $post->ID );
+		$selected_roles  = self::get_team_role_slugs( $post->ID );
+		$selected_users  = self::get_team_member_ids( $post->ID );
+		$available_roles = self::get_editable_roles_for_post_type();
+		$available_users = self::get_eligible_users();
+
+		$roles_active = ( 'roles' === $mode );
+		$users_active = ( 'users' === $mode );
+
+		$roles_count = count( $selected_roles );
+		$users_count = count( $selected_users );
+
+		\wp_nonce_field( self::NONCE_ACTION, self::NONCE_NAME );
+		?>
+		<div id="gsdp-eam-wrap">
+
+			<!-- Status badge -->
+			<div class="gsdp-eam-status">
+				<?php if ( 'off' === $mode ) : ?>
+					<span class="gsdp-eam-badge gsdp-eam-badge--off">
+						<span class="dashicons dashicons-unlock"></span>
+						<?php esc_html_e( 'Open access', 'wsuwp-plugin-graduate-school' ); ?>
+					</span>
+				<?php elseif ( 'roles' === $mode ) : ?>
+					<span class="gsdp-eam-badge gsdp-eam-badge--active">
+						<span class="dashicons dashicons-groups"></span>
+						<?php
+						printf(
+							/* translators: %d: number of roles */
+							esc_html( _n( '%d role assigned', '%d roles assigned', $roles_count, 'wsuwp-plugin-graduate-school' ) ),
+							$roles_count
+						);
+						?>
+					</span>
+				<?php else : ?>
+					<span class="gsdp-eam-badge gsdp-eam-badge--active">
+						<span class="dashicons dashicons-admin-users"></span>
+						<?php
+						printf(
+							/* translators: %d: number of users */
+							esc_html( _n( '%d user assigned', '%d users assigned', $users_count, 'wsuwp-plugin-graduate-school' ) ),
+							$users_count
+						);
+						?>
+					</span>
+				<?php endif; ?>
+			</div>
+
+			<!-- Segmented-control mode selector -->
+			<div class="gsdp-eam-modes">
+				<button type="button" class="gsdp-eam-mode-btn<?php echo 'off' === $mode ? ' active' : ''; ?>" data-mode="off">
+					<span class="dashicons dashicons-no-alt"></span> <?php esc_html_e( 'Off', 'wsuwp-plugin-graduate-school' ); ?>
+				</button>
+				<button type="button" class="gsdp-eam-mode-btn<?php echo 'roles' === $mode ? ' active' : ''; ?>" data-mode="roles">
+					<span class="dashicons dashicons-groups"></span> <?php esc_html_e( 'Roles', 'wsuwp-plugin-graduate-school' ); ?>
+				</button>
+				<button type="button" class="gsdp-eam-mode-btn<?php echo 'users' === $mode ? ' active' : ''; ?>" data-mode="users">
+					<span class="dashicons dashicons-admin-users"></span> <?php esc_html_e( 'Users', 'wsuwp-plugin-graduate-school' ); ?>
+				</button>
+				<input type="hidden" name="gsdp_team_access_mode" id="gsdp_team_access_mode" value="<?php echo esc_attr( $mode ); ?>" />
+			</div>
+
+			<!-- Tabbed panel -->
+			<div id="gsdp-eam-panels" <?php echo 'off' === $mode ? 'style="display:none;"' : ''; ?>>
+
+				<ul id="gsdp-eam-tabs">
+					<li<?php echo $roles_active ? ' class="active"' : ''; ?>>
+						<a href="#gsdp-team-panel-roles">
+							<?php esc_html_e( 'Roles', 'wsuwp-plugin-graduate-school' ); ?>
+							<span class="gsdp-eam-count" id="gsdp-eam-roles-count"><?php echo (int) $roles_count; ?></span>
+						</a>
+					</li>
+					<li<?php echo $users_active ? ' class="active"' : ''; ?>>
+						<a href="#gsdp-team-panel-users">
+							<?php esc_html_e( 'Users', 'wsuwp-plugin-graduate-school' ); ?>
+							<span class="gsdp-eam-count" id="gsdp-eam-users-count"><?php echo (int) $users_count; ?></span>
+						</a>
+					</li>
+				</ul>
+
+				<!-- Roles tab panel -->
+				
+				<div id="gsdp-team-panel-roles" class="gsdp-eam-tab-panel" <?php echo ! $roles_active ? 'style="display:none;"' : ''; ?>>
+					<div class="gsdp-multiselect-loader" aria-hidden="true">
+						<span class="gsdp-multiselect-loader-spinner"></span>
+						<span class="gsdp-multiselect-loader-text"><?php esc_html_e( 'Loading…', 'wsuwp-plugin-graduate-school' ); ?></span>
+					</div>
+					<select multiple name="gsdp_team_roles[]" id="gsdp_team_roles">
+						<?php foreach ( $available_roles as $role_slug => $role_name ) : ?>
+							<option
+								value="<?php echo esc_attr( $role_slug ); ?>"
+								<?php if ( 'administrator' === $role_slug ) : ?>selected disabled
+								<?php elseif ( in_array( $role_slug, $selected_roles, true ) ) : ?>selected<?php endif; ?>
+							>
+								<?php echo esc_html( $role_name ); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+				</div>
+
+				<!-- Users tab panel -->
+				<div id="gsdp-team-panel-users" class="gsdp-eam-tab-panel" <?php echo ! $users_active ? 'style="display:none;"' : ''; ?>>
+					<div class="gsdp-multiselect-loader" aria-hidden="true">
+						<span class="gsdp-multiselect-loader-spinner"></span>
+						<span class="gsdp-multiselect-loader-text"><?php esc_html_e( 'Loading…', 'wsuwp-plugin-graduate-school' ); ?></span>
+					</div>
+					<select multiple name="gsdp_team_members[]" id="gsdp_team_members">
+						<?php foreach ( $available_users as $user_object ) :
+							$user     = new \WP_User( $user_object->ID );
+							$is_admin = in_array( 'administrator', $user->roles, true );
+							?>
+							<option
+								value="<?php echo absint( $user_object->ID ); ?>"
+								<?php if ( $is_admin ) : ?>selected disabled
+								<?php elseif ( in_array( (int) $user_object->ID, $selected_users, true ) ) : ?>selected<?php endif; ?>
+							>
+								<?php echo esc_attr( $user->user_login ); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+				</div>
+
+			</div>
+
+		</div>
+		<?php
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers for the meta box
+	// ------------------------------------------------------------------
+
+	/**
+	 * Return role_slug => translated role name for roles with edit_posts.
+	 *
+	 * @return array
+	 */
+	private static function get_editable_roles_for_post_type() {
+		global $wp_roles;
+
+		$post_type_object = \get_post_type_object( self::POST_TYPE );
+		$edit_posts_cap   = $post_type_object ? $post_type_object->cap->edit_posts : 'edit_posts';
+		$roles            = \get_editable_roles();
+		$result           = array();
+
+		foreach ( $roles as $role_slug => $role_data ) {
+			$role = \get_role( $role_slug );
+			if ( $role && $role->has_cap( $edit_posts_cap ) ) {
+				$result[ $role_slug ] = \translate_user_role( $wp_roles->roles[ $role_slug ]['name'] );
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Return all users registered in the system (for EAM user assignment).
+	 *
+	 * @return \WP_User[]
+	 */
+	private static function get_eligible_users() {
+		return \get_users( array(
+			'orderby' => 'user_login',
+			'order'   => 'ASC',
+		) );
+	}
+
+	// ------------------------------------------------------------------
+	// Persist
+	// ------------------------------------------------------------------
+
+	/**
+	 * Save the access mode, allowed roles, and team member IDs.
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object.
+	 */
+	public static function save_team_members( $post_id, $post ) {
+		if ( \defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( 'auto-draft' === $post->post_status ) {
+			return;
+		}
+
+		if ( ! isset( $_POST[ self::NONCE_NAME ] ) || ! \wp_verify_nonce( $_POST[ self::NONCE_NAME ], self::NONCE_ACTION ) ) {
+			return;
+		}
+
+		if ( ! \current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		// Access mode.
+		$mode = isset( $_POST['gsdp_team_access_mode'] ) ? \sanitize_text_field( $_POST['gsdp_team_access_mode'] ) : 'off';
+
+		if ( ! in_array( $mode, array( 'off', 'roles', 'users' ), true ) ) {
+			$mode = 'off';
+		}
+
+		\update_post_meta( $post_id, self::META_KEY_MODE, $mode );
+
+		if ( 'off' === $mode ) {
+			\delete_post_meta( $post_id, 'eam_enable_custom_access' );
+		} else {
+			\update_post_meta( $post_id, 'eam_enable_custom_access', $mode );
+		}
+
+		// Roles — save when mode is 'roles', preserve existing when mode is 'users'.
+		if ( 'roles' === $mode ) {
+			$role_slugs = array();
+			if ( ! empty( $_POST['gsdp_team_roles'] ) && is_array( $_POST['gsdp_team_roles'] ) ) {
+				$role_slugs = array_map( 'sanitize_text_field', $_POST['gsdp_team_roles'] );
+			}
+			\update_post_meta( $post_id, self::META_KEY_ROLES, $role_slugs );
+			\update_post_meta( $post_id, 'eam_allowed_roles', $role_slugs );
+		} elseif ( 'off' === $mode ) {
+			\delete_post_meta( $post_id, self::META_KEY_ROLES );
+		}
+
+		// Users — save when mode is 'users', preserve existing when mode is 'roles'.
+		if ( 'users' === $mode ) {
+			$member_ids = array();
+			if ( ! empty( $_POST['gsdp_team_members'] ) && is_array( $_POST['gsdp_team_members'] ) ) {
+				$member_ids = array_map( 'absint', $_POST['gsdp_team_members'] );
+				$member_ids = array_values( array_unique( array_filter( $member_ids ) ) );
+			}
+			\update_post_meta( $post_id, self::META_KEY_MEMBERS, $member_ids );
+			\update_post_meta( $post_id, 'eam_allowed_users', $member_ids );
+		} elseif ( 'off' === $mode ) {
+			\delete_post_meta( $post_id, self::META_KEY_MEMBERS );
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Admin assets
+	// ------------------------------------------------------------------
+
+	public static function enqueue_assets( $hook_suffix ) {
+		if ( ! in_array( $hook_suffix, array( 'post.php', 'post-new.php' ), true ) ) {
+			return;
+		}
+
+		$screen = \get_current_screen();
+
+		if ( ! $screen || self::POST_TYPE !== $screen->id ) {
+			return;
+		}
+
+		// Plugin styles & script (custom multi-select, no external JS).
+		
+		\wp_enqueue_script(
+			'gsdp-team',
+			Plugin::get( 'url' ) . 'js/factsheet-team.js',
+			array( 'jquery' ),
+			Plugin::get( 'version' ),
+			true
+		);
+
+		\wp_enqueue_style(
+			'gsdp-team',
+			Plugin::get( 'url' ) . 'css/factsheet-team.css',
+			array(),
+			Plugin::get( 'version' )
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// Public API – reading access state
+	// ------------------------------------------------------------------
+
+	/**
+	 * Get the access mode for a factsheet.
+	 *
+	 * Falls back to EAM data when the new key has not been saved yet.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string 'off', 'roles', or 'users'.
+	 */
+	public static function get_access_mode( $post_id ) {
+		$mode = \get_post_meta( $post_id, self::META_KEY_MODE, true );
+
+		if ( in_array( $mode, array( 'off', 'roles', 'users' ), true ) ) {
+			return $mode;
+		}
+
+		// Backward compatibility with EAM.
+		$eam = \get_post_meta( $post_id, 'eam_enable_custom_access', true );
+
+		if ( in_array( $eam, array( 'roles', 'users' ), true ) ) {
+			return $eam;
+		}
+
+		return 'off';
+	}
+
+	/**
+	 * Get the allowed role slugs for a factsheet.
+	 *
+	 * Falls back to EAM data when the new key has not been saved yet.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string[] Array of role slugs.
+	 */
+	public static function get_team_role_slugs( $post_id ) {
+		$roles = \get_post_meta( $post_id, self::META_KEY_ROLES, true );
+
+		if ( ! empty( $roles ) && is_array( $roles ) ) {
+			return $roles;
+		}
+
+		// Backward compatibility with EAM.
+		$eam_roles = \get_post_meta( $post_id, 'eam_allowed_roles', true );
+
+		if ( ! empty( $eam_roles ) && is_array( $eam_roles ) ) {
+			return $eam_roles;
+		}
+
+		return array();
+	}
+
+	/**
+	 * Get team member IDs for a factsheet.
+	 *
+	 * Falls back to EAM data when the new key has not been saved yet.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return int[] Array of user IDs.
+	 */
+	public static function get_team_member_ids( $post_id ) {
+		$members = \get_post_meta( $post_id, self::META_KEY_MEMBERS, true );
+
+		if ( ! empty( $members ) && is_array( $members ) ) {
+			return array_map( 'intval', $members );
+		}
+
+		// Backward compatibility with EAM.
+		$eam_access = \get_post_meta( $post_id, 'eam_enable_custom_access', true );
+
+		if ( 'users' === $eam_access ) {
+			$eam_users = (array) \get_post_meta( $post_id, 'eam_allowed_users', true );
+			return array_map( 'intval', array_filter( $eam_users ) );
+		}
+
+		return array();
+	}
+
+	/**
+	 * Whether team-based access control is active for a factsheet.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	public static function has_team_access( $post_id ) {
+		return 'off' !== self::get_access_mode( $post_id );
+	}
+
+	/**
+	 * Whether the given user is a team member on a factsheet
+	 * (considering both 'roles' and 'users' modes).
+	 *
+	 * @param int $user_id User ID.
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	public static function is_team_member( $user_id, $post_id ) {
+		$mode = self::get_access_mode( $post_id );
+
+		if ( 'users' === $mode ) {
+			$members = self::get_team_member_ids( $post_id );
+			return in_array( (int) $user_id, $members, true );
+		}
+
+		if ( 'roles' === $mode ) {
+			$allowed_roles = self::get_team_role_slugs( $post_id );
+			$user          = new \WP_User( $user_id );
+
+			return ! empty( $user->roles ) && count( array_intersect( $user->roles, $allowed_roles ) ) > 0;
+		}
+
+		return false;
+	}
+
+	// ------------------------------------------------------------------
+	// Capability mapping
+	// ------------------------------------------------------------------
+
+	/**
+	 * Controls edit and delete capabilities for factsheets based on
+	 * team membership.
+	 *
+	 * When team access is active:
+	 *  - Team members (non-admin) may edit but NOT delete.
+	 *  - Non-team, non-admin users are denied edit access.
+	 *  - Administrators always retain full access.
+	 *
+	 * @param string[] $caps    Primitive caps required.
+	 * @param string   $cap     Capability being checked.
+	 * @param int      $user_id User ID.
+	 * @param array    $args    Additional arguments (post ID, etc.).
+	 * @return string[]
+	 */
+	public static function map_meta_cap( $caps, $cap, $user_id, $args ) {
+		$edit_caps   = array( 'edit_post', 'edit_page', 'edit_others_posts', 'edit_others_pages', 'publish_posts', 'publish_pages' );
+		$delete_caps = array( 'delete_post', 'delete_page' );
+
+		if ( ! in_array( $cap, array_merge( $edit_caps, $delete_caps ), true ) ) {
+			return $caps;
+		}
+
+		$post_id = isset( $args[0] ) ? (int) $args[0] : null;
+
+		if ( ! $post_id && ! empty( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$post_id = (int) $_GET['post'];
+		}
+
+		if ( ! $post_id && ! empty( $_POST['post_ID'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$post_id = (int) $_POST['post_ID'];
+		}
+
+		if ( ! $post_id ) {
+			return $caps;
+		}
+
+		if ( self::POST_TYPE !== \get_post_type( $post_id ) ) {
+			return $caps;
+		}
+
+		if ( ! self::has_team_access( $post_id ) ) {
+			return $caps;
+		}
+
+		$user = new \WP_User( $user_id );
+
+		if ( in_array( 'administrator', $user->roles, true ) ) {
+			return $caps;
+		}
+
+		$is_member = self::is_team_member( $user_id, $post_id );
+
+		if ( in_array( $cap, $delete_caps, true ) ) {
+			if ( $is_member ) {
+				$caps[] = 'do_not_allow';
+			}
+		} else {
+			if ( $is_member ) {
+				$caps = array();
+			} else {
+				$caps[] = 'do_not_allow';
+			}
+		}
+
+		return $caps;
+	}
+}
+
+Factsheet_Team::init();

--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -27,6 +27,8 @@ class Plugin {
 
 	public static function init() {
 
+		require_once __DIR__ . '/factsheet-team.php';
+
 		require_once __DIR__ . '/shortcode.php';
 
 		require_once __DIR__ . '/single.php';

--- a/js/factsheet-team.js
+++ b/js/factsheet-team.js
@@ -1,0 +1,351 @@
+(function ($) {
+	'use strict';
+
+	$(function () {
+		var $wrap        = $('#gsdp-eam-wrap');
+		var $modeInput   = $('#gsdp_team_access_mode');
+		var $modeButtons = $wrap.find('.gsdp-eam-mode-btn');
+		var $panels      = $('#gsdp-eam-panels');
+		var $tabs        = $('#gsdp-eam-tabs');
+		var $rolesSelect = $('#gsdp_team_roles');
+		var $usersSelect = $('#gsdp_team_members');
+		var $statusWrap  = $wrap.find('.gsdp-eam-status');
+		var $rolesCount  = $('#gsdp-eam-roles-count');
+		var $usersCount  = $('#gsdp-eam-users-count');
+
+		if (!$rolesSelect.length || !$usersSelect.length) {
+			return;
+		}
+
+		// ---------------------------------------------------------------
+		// Custom multi-select widget (replaces Chosen)
+		// ---------------------------------------------------------------
+
+	function buildMultiSelect($select, opts) {
+		var placeholder = opts.placeholder || 'Select...';
+		var noResultsText = opts.noResultsText || 'No results found';
+
+		$select.hide();
+
+		var $container = $('<div class="gsdp-multiselect">');
+		var $inner = $('<div class="gsdp-multiselect-inner">');
+		var $chips = $('<div class="gsdp-multiselect-chips">');
+		var $searchWrap = $('<div class="gsdp-multiselect-search-wrap">');
+		var $search = $('<input type="text" class="gsdp-multiselect-search" placeholder="' + placeholder + '" autocomplete="off">');
+		var $dropdown = $('<div class="gsdp-multiselect-dropdown">');
+		var $list = $('<ul class="gsdp-multiselect-results">');
+		var $noResults = $('<li class="gsdp-multiselect-no-results">' + noResultsText + '</li>');
+
+		$searchWrap.append($search);
+		$inner.append($chips).append($searchWrap);
+		$dropdown.append($list);
+		$container.append($inner).append($dropdown);
+		$select.after($container);
+
+		function getOptions() {
+			var items = [];
+			$select.find('option').each(function () {
+				var $opt = $(this);
+				items.push({
+					value: $opt.val(),
+					text: $opt.text(),
+					selected: $opt.prop('selected'),
+					disabled: $opt.prop('disabled')
+				});
+			});
+			return items;
+		}
+
+		function isSelected(value) {
+			value = String(value);
+			return $select.find('option[value="' + value.replace(/"/g, '\\"') + '"]').prop('selected');
+		}
+
+		function setSelected(value, selected) {
+			value = String(value);
+			var $opt = $select.find('option[value="' + value.replace(/"/g, '\\"') + '"]');
+			if ($opt.length && !$opt.prop('disabled')) {
+				$opt.prop('selected', !!selected);
+			}
+		}
+
+		function renderChips() {
+			var html = '';
+			$select.find('option:selected').each(function () {
+				var $opt = $(this);
+				var v = $opt.val();
+				var text = $opt.text();
+				var disabled = $opt.prop('disabled');
+				html += '<span class="gsdp-multiselect-chip' + (disabled ? ' is-disabled' : '') + '" data-value="' + $('<div>').text(v).html() + '">';
+				html += '<span class="gsdp-multiselect-chip-text">' + $('<div>').text(text).html() + '</span>';
+				if (!disabled) {
+					html += '<button type="button" class="gsdp-multiselect-chip-remove" aria-label="Remove">&times;</button>';
+				}
+				html += '</span>';
+			});
+			$chips.html(html);
+		}
+
+		function filterList(searchVal) {
+			searchVal = (searchVal || '').toLowerCase();
+			var visible = 0;
+			$list.find('li[data-value]').each(function () {
+				var $li = $(this);
+				var text = $li.data('text') || '';
+				var show = !searchVal || text.toLowerCase().indexOf(searchVal) !== -1;
+				$li.toggle(show);
+				if (show) visible++;
+			});
+			$list.find('.gsdp-multiselect-no-results').toggle(visible === 0);
+		}
+
+		function renderList() {
+			$list.empty();
+			var options = getOptions();
+			options.forEach(function (o) {
+				var $li = $('<li>')
+					.attr('data-value', o.value)
+					.data('text', o.text)
+					.data('disabled', o.disabled)
+					.text(o.text)
+					.toggleClass('is-selected', o.selected)
+					.toggleClass('is-disabled', o.disabled);
+				if (!o.disabled) {
+					$li.attr('tabindex', 0).css('cursor', 'pointer');
+				}
+				$list.append($li);
+			});
+			$list.append($noResults);
+			$noResults.hide();
+			filterList($search.val());
+		}
+		// Remove loader that was shown until widget was built
+		$select.prev('.gsdp-multiselect-loader').remove();
+
+		function openDropdown() {
+			$container.addClass('is-open');
+				$dropdown.show();
+			$search.focus();
+			filterList($search.val());
+		}
+
+		function closeDropdown() {
+			$container.removeClass('is-open');
+			$dropdown.hide();
+			$search.val('');
+			filterList('');
+		}
+
+		function toggleOption(value) {
+			value = String(value);
+			var $opt = $select.find('option[value="' + value.replace(/"/g, '\\"') + '"]');
+			if ($opt.length && !$opt.prop('disabled')) {
+				$opt.prop('selected', !$opt.prop('selected'));
+				renderChips();
+				renderList();
+				$select.trigger('change');
+			}
+		}
+
+		// Chips remove
+		$container.on('click', '.gsdp-multiselect-chip-remove', function (e) {
+			e.preventDefault();
+			e.stopPropagation();
+			var val = $(this).closest('.gsdp-multiselect-chip').data('value');
+			setSelected(String(val), false);
+			renderChips();
+			renderList();
+			$select.trigger('change');
+		});
+
+		// List item click
+		$list.on('click', 'li[data-value]', function (e) {
+			e.preventDefault();
+			var $li = $(this);
+			if ($li.hasClass('is-disabled')) return;
+			toggleOption($li.data('value'));
+		});
+
+		// Search
+		$search.on('input', function () {
+			filterList($(this).val());
+		});
+
+		$search.on('focus', function () {
+			openDropdown();
+		});
+
+		$inner.on('click', function (e) {
+			if (!$(e.target).closest('.gsdp-multiselect-chip-remove').length) {
+				openDropdown();
+			}
+		});
+
+		// Close on outside click
+		$(document).on('click.gsdpMultiselect', function (e) {
+			if (!$(e.target).closest($container).length) {
+				closeDropdown();
+			}
+		});
+
+		// Initial render
+		renderChips();
+		renderList();
+
+		// Re-render when select is changed programmatically
+		$select.on('change', function () {
+			renderChips();
+			renderList();
+		});
+
+		return {
+			destroy: function () {
+				$(document).off('click.gsdpMultiselect');
+				$container.remove();
+				$select.show();
+			},
+			refresh: function () {
+				renderChips();
+				renderList();
+			}
+		};
+	}
+
+	// Init custom multi-selects
+	buildMultiSelect($rolesSelect, { placeholder: 'Select roles...', noResultsText: 'No roles found matching' });
+	buildMultiSelect($usersSelect, { placeholder: 'Search and select users...', noResultsText: 'No users found matching' });
+
+	// ---------------------------------------------------------------
+	// Status badge
+	// ---------------------------------------------------------------
+
+	function updateStatus() {
+		var mode = $modeInput.val();
+		var html = '';
+
+		if (mode === 'off') {
+			html = '<span class="gsdp-eam-badge gsdp-eam-badge--off">' +
+				'<span class="dashicons dashicons-unlock"></span> Open access</span>';
+		} else if (mode === 'roles') {
+			var rc = $rolesSelect.val() ? $rolesSelect.val().length : 0;
+			html = '<span class="gsdp-eam-badge gsdp-eam-badge--active">' +
+				'<span class="dashicons dashicons-groups"></span> ' +
+				rc + (rc === 1 ? ' role' : ' roles') + ' assigned</span>';
+		} else {
+			var uc = $usersSelect.val() ? $usersSelect.val().length : 0;
+			html = '<span class="gsdp-eam-badge gsdp-eam-badge--active">' +
+				'<span class="dashicons dashicons-admin-users"></span> ' +
+				uc + (uc === 1 ? ' user' : ' users') + ' assigned</span>';
+		}
+
+		$statusWrap.html(html);
+	}
+
+	function updateCounts() {
+		var rc = $rolesSelect.val() ? $rolesSelect.val().length : 0;
+		var uc = $usersSelect.val() ? $usersSelect.val().length : 0;
+		$rolesCount.text(rc);
+		$usersCount.text(uc);
+	}
+
+	$rolesSelect.on('change', function () { updateCounts(); updateStatus(); });
+	$usersSelect.on('change', function () { updateCounts(); updateStatus(); });
+
+	// ---------------------------------------------------------------
+	// Tab switching
+	// ---------------------------------------------------------------
+
+	function activateTab(panelId) {
+		$tabs.find('li').removeClass('active');
+		$tabs.find('a[href="' + panelId + '"]').parent('li').addClass('active');
+
+		$panels.find('.gsdp-eam-tab-panel').hide();
+		$(panelId).show();
+	}
+
+	$tabs.on('click', 'a', function (e) {
+		e.preventDefault();
+		var panel = $(this).attr('href');
+		activateTab(panel);
+
+		var newMode = (panel === '#gsdp-team-panel-roles') ? 'roles' : 'users';
+		$modeInput.val(newMode);
+		$modeButtons.removeClass('active');
+		$modeButtons.filter('[data-mode="' + newMode + '"]').addClass('active');
+		updateStatus();
+	});
+
+	// ---------------------------------------------------------------
+	// Segmented-control mode buttons
+	// ---------------------------------------------------------------
+
+	$modeButtons.on('click', function () {
+		var mode = $(this).data('mode');
+		$modeInput.val(mode);
+		$modeButtons.removeClass('active');
+		$(this).addClass('active');
+
+		if (mode === 'off') {
+			$panels.slideUp(150);
+		} else {
+			$panels.slideDown(150, function () {
+				if (mode === 'roles') {
+					activateTab('#gsdp-team-panel-roles');
+				} else {
+					activateTab('#gsdp-team-panel-users');
+				}
+			});
+		}
+
+		updateStatus();
+	});
+
+	// ---------------------------------------------------------------
+	// Initial state
+	// ---------------------------------------------------------------
+
+		(function init() {
+			var mode = $modeInput.val();
+
+			if (mode === 'off') {
+				$panels.hide();
+			} else if (mode === 'roles') {
+				activateTab('#gsdp-team-panel-roles');
+			} else {
+				activateTab('#gsdp-team-panel-users');
+			}
+
+			updateCounts();
+		})();
+
+		// Before submit: inject hidden inputs so the selection is reliably
+		// included in $_POST even though the native <select> is hidden.
+		$('#post').on('submit', function () {
+			$('.gsdp-multiselect').each(function () {
+				var $container = $(this);
+				var $select = $container.prev('select');
+				if (!$select.length) {
+					return;
+				}
+
+				var fieldName = $select.attr('name');
+				if (!fieldName) {
+					return;
+				}
+
+				// Remove the name from the native select so it doesn't
+				// double-submit alongside the hidden inputs.
+				$select.removeAttr('name');
+
+				// Collect selected (non-disabled) values from the select.
+				$select.find('option:selected:not(:disabled)').each(function () {
+					$('<input type="hidden">')
+						.attr('name', fieldName)
+						.val($(this).val())
+						.appendTo($select.closest('form'));
+				});
+			});
+		});
+	});
+
+})(jQuery);

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -276,9 +276,6 @@ class WSUWP_Graduate_Degree_Programs {
 		add_filter( "auth_post_meta_gsdp_include_in_programs_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
 		add_filter( 'wp_insert_post_data', array( $this, 'manage_factsheet_title_update' ), 10, 2 );
 
-		// Block taxonomy term assignment for restricted contributors.
-		add_action( 'set_object_terms', array( $this, 'maybe_restore_taxonomy_terms' ), 10, 6 );
-
 		add_action( 'pre_get_posts', array( $this, 'adjust_factsheet_archive_query' ) );
 		add_action( 'template_redirect', array( $this, 'redirect_old_factsheet_urls' ) );
 		add_action( 'template_redirect', array( $this, 'redirect_private_factsheets' ) );
@@ -1218,8 +1215,6 @@ class WSUWP_Graduate_Degree_Programs {
 
 		if ( 'users' === $enable_custom_access ) {
 			$allowed_users = (array) get_post_meta( $post_id, 'eam_allowed_users', true );
-			//log allowed users
-			error_log( print_r( $allowed_users, true ) );
 
 			if ( in_array( $user_id, $allowed_users ) ) { // @codingStandardsIgnoreLine (Converting user IDs to ints is not worth it)
 				return true;
@@ -1323,77 +1318,15 @@ class WSUWP_Graduate_Degree_Programs {
 	 */
 	public function manage_factsheet_title_update( $data, $postarr ) {
 		$user = wp_get_current_user();
-		//print user id
-		error_log( 'User ID: ' . $user->ID );	
-		error_log( 'Post ID: ' . $postarr['ID'] );
-		error_log( 'User is restricted contributor: ' . $this->user_is_restricted_contributor( $user->ID, $postarr['ID'] ) );
-		error_log( 'Data post title: ' . $data['post_title'] );
 
 		if ( isset( $postarr['ID'] ) && $this->user_is_restricted_contributor( $user->ID, $postarr['ID'] ) ) {
 			$existing_title = get_post_field( 'post_title', absint( $postarr['ID'] ) );
-			error_log( 'Existing title: ' . $existing_title );
 			if ( ! empty( $existing_title ) && $data['post_title'] !== $existing_title ) {
 				$data['post_title'] = $existing_title;
-				error_log( 'Data post title: ' . $data['post_title'] );
 			}
-			error_log( 'Data post title: ' . $data['post_title'] );
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Restores taxonomy terms if a restricted contributor tries to change them.
-	 *
-	 * This method hooks into 'set_object_terms' and restores the original terms
-	 * for Program Names and Degree Types taxonomies if the current user is a
-	 * restricted contributor.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @param int    $object_id  Object ID.
-	 * @param array  $terms      An array of object term IDs or slugs.
-	 * @param array  $tt_ids     An array of term taxonomy IDs.
-	 * @param string $taxonomy   Taxonomy slug.
-	 * @param bool   $append     Whether to append new terms to the old terms.
-	 * @param array  $old_tt_ids Old array of term taxonomy IDs.
-	 */
-	public function maybe_restore_taxonomy_terms( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
-		// Only check for our restricted taxonomies
-		$restricted_taxonomies = array( 'gs-program-name', 'gs-degree-type' );
-
-		if ( ! in_array( $taxonomy, $restricted_taxonomies, true ) ) {
-			return;
-		}
-
-		// Only check for our post type
-		if ( get_post_type( $object_id ) !== $this->post_type_slug ) {
-			return;
-		}
-
-		$user_id = get_current_user_id();
-
-		// If user is a restricted contributor, restore the old terms
-		if ( $this->user_is_restricted_contributor( $user_id, $object_id ) ) {
-			// Remove the action temporarily to avoid infinite loop
-			remove_action( 'set_object_terms', array( $this, 'maybe_restore_taxonomy_terms' ), 10 );
-
-			// Restore the old terms
-			$old_term_ids = array();
-			if ( ! empty( $old_tt_ids ) ) {
-				foreach ( $old_tt_ids as $old_tt_id ) {
-					$term = get_term_by( 'term_taxonomy_id', $old_tt_id );
-					if ( $term ) {
-						$old_term_ids[] = $term->term_id;
-					}
-				}
-			}
-
-			wp_set_object_terms( $object_id, $old_term_ids, $taxonomy );
-
-			// Re-add the action
-			add_action( 'set_object_terms', array( $this, 'maybe_restore_taxonomy_terms' ), 10, 6 );
-		}
 	}
 
 	/**

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -302,11 +302,14 @@ class WSUWP_Graduate_Degree_Programs {
 
 			wp_enqueue_script( 'gsdp-factsheet-admin' );
 
-			// Disable title and permalink for restricted contributors
+			// Disable title and permalink for restricted contributors (only on published posts, not new/draft ones)
 			$user_id = get_current_user_id();
 			$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$post_status = get_post_status( $post_id );
+			$is_new_or_draft = empty( $post_id ) || in_array( $post_status, array( 'auto-draft', 'draft' ), true );
 
-			if ( $this->user_is_restricted_contributor( $user_id, $post_id ) ) {
+			// Only apply restrictions when editing published factsheets, not when creating new ones or editing drafts
+			if ( ! $is_new_or_draft && $this->user_is_restricted_contributor( $user_id, $post_id ) ) {
 				// Add inline CSS to visually disable restricted fields
 				$custom_css = '
 					/* Disable title field */
@@ -1231,14 +1234,17 @@ class WSUWP_Graduate_Degree_Programs {
 	 * - They are assigned via Editorial Access Manager (EAM), OR
 	 * - They have a WordPress role of 'contributor', 'author', or 'editor' (only 'administrator' has full access)
 	 *
-	 * Restricted users cannot edit:
+	 * Restricted users cannot edit (on existing factsheets only):
 	 * - Factsheet title
 	 * - Factsheet display name
 	 * - Include in programs list
 	 * - Program Names taxonomy
 	 * - Degree Types taxonomy
 	 *
+	 * Note: No restrictions apply when creating a NEW factsheet or editing a DRAFT - all fields are editable.
+	 *
 	 * @since 1.4.0
+	 * @since 1.5.0 Added check for new posts and drafts - no restrictions until published.
 	 *
 	 * @param int      $user_id The user ID to check.
 	 * @param int|null $post_id Optional. The post ID for EAM check.
@@ -1246,6 +1252,12 @@ class WSUWP_Graduate_Degree_Programs {
 	 * @return bool True if the user is a restricted contributor, false otherwise.
 	 */
 	public function user_is_restricted_contributor( $user_id, $post_id = null ) {
+		// No restrictions for new posts or drafts - allow full access when creating/drafting a factsheet
+		$post_status = $post_id ? get_post_status( $post_id ) : '';
+		if ( empty( $post_id ) || in_array( $post_status, array( 'auto-draft', 'draft' ), true ) ) {
+			return false;
+		}
+
 		// Check EAM assignment (if post_id provided)
 		if ( $post_id && $this->user_is_eam_user( $user_id, $post_id ) ) {
 			return true;

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -63,6 +63,7 @@ class WSUWP_Graduate_Degree_Programs {
 			'type' => 'bool',
 			'sanitize_callback' => 'absint',
 			'meta_field_callback' => array( __CLASS__, 'display_bool_meta_field' ),
+			'restricted' => true,
 			'location' => 'primary',
 		),
 		'gsdp_grad_students_total' => array(
@@ -268,11 +269,11 @@ class WSUWP_Graduate_Degree_Programs {
 		add_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 200, 4 );
 
 		// Several fields are restricted to full editors or admins.
-		// add_filter( "auth_post_{$this->post_type_slug}_meta_gsdp_degree_id", array( $this, 'can_edit_restricted_field' ), 100, 4 );
-		add_filter( "auth_post_{$this->post_type_slug}_meta_gsdp_degree_shortname", array( $this, 'can_edit_restricted_field' ), 100, 4 );
-		add_filter( "auth_post_{$this->post_type_slug}_meta_gsdp_student_learning_outcome", array( $this, 'can_edit_restricted_field' ), 100, 4 );
-		add_filter( "auth_post_{$this->post_type_slug}_meta_gsdp_include_in_programs", array( $this, 'can_edit_restricted_field' ), 100, 4 );
-
+		// Updated to use new filter format (since WP 4.9.8): auth_post_meta_{meta_key}_for_{post_type}
+		// add_filter( "auth_post_meta_gsdp_degree_id_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
+		add_filter( "auth_post_meta_gsdp_degree_shortname_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
+		add_filter( "auth_post_meta_gsdp_student_learning_outcome_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
+		add_filter( "auth_post_meta_gsdp_include_in_programs_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
 		add_filter( 'wp_insert_post_data', array( $this, 'manage_factsheet_title_update' ), 10, 2 );
 
 		// Block taxonomy term assignment for restricted contributors.
@@ -289,6 +290,7 @@ class WSUWP_Graduate_Degree_Programs {
 	 * Enqueue scripts and styles used in the admin.
 	 *
 	 * @since 0.4.0
+	 * @since 1.4.0 Added inline styles to disable title/permalink for restricted contributors.
 	 *
 	 * @param string $hook_suffix
 	 */
@@ -302,6 +304,76 @@ class WSUWP_Graduate_Degree_Programs {
 			wp_register_script( 'gsdp-factsheet-admin', WSUWP\Plugin\Graduate\Plugin::get('url'). '/js/factsheet-admin.min.js', array( 'jquery', 'underscore', 'jquery-ui-autocomplete' ), WSUWP_Graduate_School_Theme()->theme_version(), true );
 
 			wp_enqueue_script( 'gsdp-factsheet-admin' );
+
+			// Disable title and permalink for restricted contributors
+			$user_id = get_current_user_id();
+			$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+			if ( $this->user_is_restricted_contributor( $user_id, $post_id ) ) {
+				// Add inline CSS to visually disable restricted fields
+				$custom_css = '
+					/* Disable title field */
+					#titlewrap input#title {
+						pointer-events: none;
+						background-color: #f0f0f0;
+						color: #666;
+						cursor: not-allowed;
+					}
+					/* Disable permalink edit */
+					#edit-slug-box,
+					#edit-slug-buttons,
+					.edit-slug {
+						pointer-events: none;
+						opacity: 0.5;
+					}
+					#edit-slug-buttons {
+						display: none;
+					}
+					/* Disable Program Names panel (greyed out) */
+					#gs-program-namediv {
+						pointer-events: none;
+						opacity: 0.5;
+					}
+					#gs-program-namediv .inside {
+						background-color: #f0f0f0;
+					}
+					#gs-program-namediv input,
+					#gs-program-namediv select,
+					#gs-program-namediv button {
+						cursor: not-allowed;
+					}
+					/* Disable Degree Types panel (greyed out) */
+					#tagsdiv-gs-degree-type {
+						pointer-events: none;
+						opacity: 0.5;
+					}
+					#tagsdiv-gs-degree-type .inside {
+						background-color: #f0f0f0;
+					}
+					#tagsdiv-gs-degree-type input,
+					#tagsdiv-gs-degree-type select,
+					#tagsdiv-gs-degree-type button {
+						cursor: not-allowed;
+					}
+				';
+				wp_add_inline_style( 'gsdp-admin', $custom_css );
+
+				// Add inline JS to make fields readonly/disabled
+				$custom_js = '
+					jQuery(document).ready(function($) {
+						// Make title readonly
+						$("#title").prop("readonly", true);
+						// Disable permalink edit button
+						$("#edit-slug-buttons .edit-slug").remove();
+						$(".edit-slug").remove();
+						// Disable inputs in Program Names panel
+						$("#gs-program-namediv input, #gs-program-namediv select, #gs-program-namediv button").prop("disabled", true);
+						// Disable inputs in Degree Types panel
+						$("#tagsdiv-gs-degree-type input, #tagsdiv-gs-degree-type select, #tagsdiv-gs-degree-type button").prop("disabled", true);
+					});
+				';
+				wp_add_inline_script( 'gsdp-factsheet-admin', $custom_js );
+			}
 		}
 
 		if ( in_array( $hook_suffix, array( 'edit-tags.php', 'term.php', 'term-new.php' ), true ) && in_array( get_current_screen()->taxonomy, array( 'gs-degree-type' ), true ) ) {
@@ -412,15 +484,14 @@ class WSUWP_Graduate_Degree_Programs {
 	}
 
 	/**
-	 * Removes the faculty member and contact info taxonomy boxes from the
-	 * factsheet screen. This data is managed via custom input in the primary
-	 * meta box.
+	 * Removes unnecessary meta boxes from the factsheet screen.
 	 *
-	 * Also removes Program Names and Degree Types taxonomy boxes for restricted
-	 * contributors (EAM-assigned users or users with contributor/author roles).
+	 * Note: Program Names and Degree Types taxonomy boxes are NOT removed here.
+	 * They are greyed out (disabled) via CSS/JS in admin_enqueue_scripts() for
+	 * restricted contributors.
 	 *
 	 * @since 0.7.0
-	 * @since 1.4.0 Added removal of taxonomy boxes for restricted contributors.
+	 * @since 1.4.0 Taxonomy boxes now greyed out instead of removed.
 	 *
 	 * @param string $post_type
 	 */
@@ -430,15 +501,6 @@ class WSUWP_Graduate_Degree_Programs {
 		}
 
 		remove_meta_box( 'wpseo_meta', $this->post_type_slug, 'normal' );
-
-		// Remove taxonomy meta boxes for restricted contributors
-		$user_id = get_current_user_id();
-		$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-		if ( $this->user_is_restricted_contributor( $user_id, $post_id ) ) {
-			remove_meta_box( 'gs-program-namediv', $this->post_type_slug, 'side' );
-			remove_meta_box( 'gs-degree-typediv', $this->post_type_slug, 'side' );
-		}
 	}
 
 	/**
@@ -566,7 +628,8 @@ class WSUWP_Graduate_Degree_Programs {
 		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
 		<?php
 
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
+		// Check if field is restricted and user is a restricted contributor
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
 			$disabled = 'disabled';
 		} else {
 			$disabled = '';
@@ -591,7 +654,8 @@ class WSUWP_Graduate_Degree_Programs {
 		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
 		<?php
 
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
+		// Check if field is restricted and user is a restricted contributor
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
 			$disabled = 'disabled';
 		} else {
 			$disabled = '';
@@ -606,15 +670,23 @@ class WSUWP_Graduate_Degree_Programs {
 	 * Outputs the meta field HTML used to capture meta data stored as boolean.
 	 *
 	 * @since 1.3.0
+	 * @since 1.4.0 Added support for restricted fields that are disabled for contributors.
 	 *
 	 * @param array  $meta
 	 * @param string $key
 	 * @param array  $data
 	 */
 	public function display_bool_meta_field( $meta, $key, $data ) {
+		// Check if field is restricted and user is a restricted contributor
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
+			$disabled = 'disabled';
+		} else {
+			$disabled = '';
+		}
+
 		?>
 		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
-		<select name="<?php echo esc_attr( $key ); ?>">
+		<select name="<?php echo esc_attr( $key ); ?>" <?php echo $disabled; // @codingStandardsIgnoreLine ?>>
 			<option value="0" <?php selected( 0, absint( $data[ $key ][0] ) ); ?>>No</option>
 			<option value="1" <?php selected( 1, absint( $data[ $key ][0] ) ); ?>>Yes</option>
 		</select>
@@ -1146,6 +1218,8 @@ class WSUWP_Graduate_Degree_Programs {
 
 		if ( 'users' === $enable_custom_access ) {
 			$allowed_users = (array) get_post_meta( $post_id, 'eam_allowed_users', true );
+			//log allowed users
+			error_log( print_r( $allowed_users, true ) );
 
 			if ( in_array( $user_id, $allowed_users ) ) { // @codingStandardsIgnoreLine (Converting user IDs to ints is not worth it)
 				return true;
@@ -1160,7 +1234,14 @@ class WSUWP_Graduate_Degree_Programs {
 	 *
 	 * A user is considered a restricted contributor if:
 	 * - They are assigned via Editorial Access Manager (EAM), OR
-	 * - They have a WordPress role of 'contributor' or 'author' (and not 'administrator' or 'editor')
+	 * - They have a WordPress role of 'contributor', 'author', or 'editor' (only 'administrator' has full access)
+	 *
+	 * Restricted users cannot edit:
+	 * - Factsheet title
+	 * - Factsheet display name
+	 * - Include in programs list
+	 * - Program Names taxonomy
+	 * - Degree Types taxonomy
 	 *
 	 * @since 1.4.0
 	 *
@@ -1177,8 +1258,10 @@ class WSUWP_Graduate_Degree_Programs {
 
 		// Check WordPress role
 		$user = new WP_User( $user_id );
-		$restricted_roles = array( 'contributor', 'author' );
-		$unrestricted_roles = array( 'administrator', 'editor' );
+		// Editors, Authors, and Contributors have restricted access to certain fields
+		$restricted_roles = array( 'contributor', 'author', 'editor' );
+		// Only Administrators have full unrestricted access
+		$unrestricted_roles = array( 'administrator' );
 
 		// If user has an unrestricted role, they are not a restricted contributor
 		foreach ( $unrestricted_roles as $role ) {
@@ -1240,13 +1323,20 @@ class WSUWP_Graduate_Degree_Programs {
 	 */
 	public function manage_factsheet_title_update( $data, $postarr ) {
 		$user = wp_get_current_user();
+		//print user id
+		error_log( 'User ID: ' . $user->ID );	
+		error_log( 'Post ID: ' . $postarr['ID'] );
+		error_log( 'User is restricted contributor: ' . $this->user_is_restricted_contributor( $user->ID, $postarr['ID'] ) );
+		error_log( 'Data post title: ' . $data['post_title'] );
 
 		if ( isset( $postarr['ID'] ) && $this->user_is_restricted_contributor( $user->ID, $postarr['ID'] ) ) {
 			$existing_title = get_post_field( 'post_title', absint( $postarr['ID'] ) );
-
+			error_log( 'Existing title: ' . $existing_title );
 			if ( ! empty( $existing_title ) && $data['post_title'] !== $existing_title ) {
 				$data['post_title'] = $existing_title;
+				error_log( 'Data post title: ' . $data['post_title'] );
 			}
+			error_log( 'Data post title: ' . $data['post_title'] );
 		}
 
 		return $data;

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -265,8 +265,8 @@ class WSUWP_Graduate_Degree_Programs {
 		add_action( 'add_meta_boxes', array( $this, 'remove_meta_boxes' ), 99 );
 		add_action( "save_post_{$this->post_type_slug}", array( $this, 'save_factsheet' ), 10, 2 );
 
-		// This should fire after the filter in Editorial Access Manager.
-		add_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 200, 4 );
+		// Capability mapping for team-based access is now handled by
+		// \WSUWP\Plugin\Graduate\Factsheet_Team::map_meta_cap() at priority 150.
 
 		// Several fields are restricted to full editors or admins.
 		// Updated to use new filter format (since WP 4.9.8): auth_post_meta_{meta_key}_for_{post_type}
@@ -501,6 +501,9 @@ class WSUWP_Graduate_Degree_Programs {
 		}
 
 		remove_meta_box( 'wpseo_meta', $this->post_type_slug, 'normal' );
+
+		// Team management is handled by Factsheet_Team; remove the EAM meta box if the plugin is active.
+		remove_meta_box( 'eam_access_manager', $this->post_type_slug, 'side' );
 	}
 
 	/**
@@ -1204,9 +1207,13 @@ class WSUWP_Graduate_Degree_Programs {
 	}
 
 	/**
-	 * Determines if a user has been assigned to a factsheet through Editorial Access Manager.
+	 * Determines if a user has been assigned to a factsheet as a team member.
+	 *
+	 * Delegates to {@see \WSUWP\Plugin\Graduate\Factsheet_Team::is_team_member()}
+	 * which also provides backward compatibility with legacy EAM post meta.
 	 *
 	 * @since 1.1.0
+	 * @since 1.3.0 Now delegates to the Factsheet_Team class instead of reading EAM meta directly.
 	 *
 	 * @param int $user_id
 	 * @param int $post_id
@@ -1214,24 +1221,14 @@ class WSUWP_Graduate_Degree_Programs {
 	 * @return bool
 	 */
 	public function user_is_eam_user( $user_id, $post_id ) {
-		$enable_custom_access = get_post_meta( $post_id, 'eam_enable_custom_access', true );
-
-		if ( 'users' === $enable_custom_access ) {
-			$allowed_users = (array) get_post_meta( $post_id, 'eam_allowed_users', true );
-
-			if ( in_array( $user_id, $allowed_users ) ) { // @codingStandardsIgnoreLine (Converting user IDs to ints is not worth it)
-				return true;
-			}
-		}
-
-		return false;
+		return \WSUWP\Plugin\Graduate\Factsheet_Team::is_team_member( $user_id, $post_id );
 	}
 
 	/**
 	 * Determines if a user is a restricted contributor.
 	 *
 	 * A user is considered a restricted contributor if:
-	 * - They are assigned via Editorial Access Manager (EAM), OR
+	 * - They are assigned as a am to have 2 member, OR
 	 * - They have a WordPress role of 'contributor', 'author', or 'editor' (only 'administrator' has full access)
 	 *
 	 * Restricted users cannot edit (on existing factsheets only):
@@ -1245,9 +1242,10 @@ class WSUWP_Graduate_Degree_Programs {
 	 *
 	 * @since 1.4.0
 	 * @since 1.5.0 Added check for new posts and drafts - no restrictions until published.
+	 * @since 1.6.0 Now uses Factsheet_Team for team membership instead of EAM.
 	 *
 	 * @param int      $user_id The user ID to check.
-	 * @param int|null $post_id Optional. The post ID for EAM check.
+	 * @param int|null $post_id Optional. The post ID for team membership check.
 	 *
 	 * @return bool True if the user is a restricted contributor, false otherwise.
 	 */
@@ -1291,7 +1289,7 @@ class WSUWP_Graduate_Degree_Programs {
 	 * Ensures that restricted contributors are not allowed to change restricted fields.
 	 *
 	 * Restricted contributors include:
-	 * - Users assigned via Editorial Access Manager (EAM)
+	 * - Users assigned as factsheet team members
 	 * - Users with WordPress contributor or author roles
 	 *
 	 * @since 1.1.0
@@ -1317,7 +1315,7 @@ class WSUWP_Graduate_Degree_Programs {
 	 * Prevents restricted contributors from editing a factsheet's title.
 	 *
 	 * Restricted contributors include:
-	 * - Users assigned via Editorial Access Manager (EAM)
+	 * - Users assigned as factsheet team members
 	 * - Users with WordPress contributor or author roles
 	 *
 	 * @since 1.1.0
@@ -1680,59 +1678,15 @@ class WSUWP_Graduate_Degree_Programs {
 	}
 
 	/**
-	 * Filters a user's ability to delete factsheets when they have been added as an
-	 * authorized user via Editorial Access Manager.
+	 * Deprecated. Capability mapping is now handled by
+	 * {@see \WSUWP\Plugin\Graduate\Factsheet_Team::map_meta_cap()}.
+	 *
+	 * Kept for reference; the filter hook has been removed from setup_hooks().
 	 *
 	 * @since 1.1.0
-	 *
-	 * @param array $caps
-	 * @param string $cap
-	 * @param int $user_id
-	 * @param array $args
-	 *
-	 * @return array
+	 * @deprecated 1.3.0
 	 */
 	public function filter_map_meta_cap( $caps, $cap, $user_id, $args ) {
-		$eam_caps = array(
-			'delete_page',
-			'delete_post',
-		);
-
-		if ( in_array( $cap, $eam_caps, true ) ) {
-
-			$post_id = ( isset( $args[0] ) ) ? (int) $args[0] : null;
-			if ( ! $post_id && ! empty( $_GET['post'] ) ) { // WPCS: CSRF Ok.
-				$post_id = (int) $_GET['post'];
-			}
-
-			if ( ! $post_id && ! empty( $_POST['post_ID'] ) ) { // @codingStandardsIgnoreLine (No reason to check a nonce here)
-				$post_id = (int) $_POST['post_ID'];
-			}
-
-			if ( ! $post_id ) {
-				return $caps;
-			}
-
-			$enable_custom_access = get_post_meta( $post_id, 'eam_enable_custom_access', true );
-
-			if ( ! empty( $enable_custom_access ) ) {
-				$user = new WP_User( $user_id );
-
-				// If user is admin, we do nothing
-				if ( ! in_array( 'administrator', $user->roles, true ) ) {
-
-					if ( 'users' === $enable_custom_access ) {
-						// Reset caps for allowed users to do_not_allow.
-						$allowed_users = (array) get_post_meta( $post_id, 'eam_allowed_users', true );
-
-						if ( in_array( $user_id, $allowed_users ) ) { // @codingStandardsIgnoreLine (Converting user IDs to ints is not worth it)
-							$caps[] = 'do_not_allow';
-						}
-					}
-				}
-			}
-		}
-
 		return $caps;
 	}
 


### PR DESCRIPTION
###. Allow Unrestricted Editing for New/Draft Factsheets

**File:** `legacy/class-wsuwp-graduate-degree-programs.php`

**Modified:** `user_is_restricted_contributor()` method to return `false` (not restricted) for new posts and drafts:
```php
// No restrictions for new posts or drafts - allow full access when creating/drafting a factsheet
$post_status = $post_id ? get_post_status( $post_id ) : '';
if ( empty( $post_id ) || in_array( $post_status, array( 'auto-draft', 'draft' ), true ) ) {
    return false;
}
```

**Modified:** `admin_enqueue_scripts()` method to skip CSS/JS field disabling for new/draft posts:
```php
$post_status = get_post_status( $post_id );
$is_new_or_draft = empty( $post_id ) || in_array( $post_status, array( 'auto-draft', 'draft' ), true );

// Only apply restrictions when editing published factsheets, not when creating new ones or editing drafts
if ( ! $is_new_or_draft && $this->user_is_restricted_contributor( $user_id, $post_id ) ) {
    // Apply restrictions...
}
```

---

## Behavior After Changes

### Factsheet Viewing
| Before | After |
|--------|-------|
| Only title displayed | Full factsheet details displayed (description, stats, URLs, deadlines, requirements, contacts, locations, text blocks) |

### Contributor Restrictions
| Post Status | Before | After |
|-------------|--------|-------|
| **auto-draft** (new) | Restricted | Full editing |
| **draft** | Restricted | Full editing |
| **publish** | Restricted | Restricted (no change) |
| **pending** | Restricted | Restricted (no change) |
| **private** | Restricted | Restricted (no change) |

### Restricted Fields (for published posts only)
- Factsheet title
- Factsheet display name (`gsdp_degree_shortname`)
- Include in programs list (`gsdp_include_in_programs`)
- Student learning outcome (`gsdp_student_learning_outcome`)
- Program Names taxonomy (`gs-program-name`)
- Degree Types taxonomy (`gs-degree-type`)

---
This change replaces the dependency on the Editorial Access Manager (EAM) plugin for factsheet access control. Factsheet-specific “who can edit” behavior is now handled inside the graduate school plugin via a new Factsheet Team feature, while keeping compatibility with existing EAM data and behavior.

---

## Testing Checklist

### Factsheet Display
- [ ] View a published factsheet on the front-end
- [ ] Verify all sections display: description, statistics, URLs, deadlines, requirements, contacts, locations
- [ ] Verify CSS styling matches expected layout (uses existing `.factsheet-*` classes)
- [ ] Verify no PHP warnings in error logs

### New Factsheet Creation
- [ ] Log in as a contributor/author/editor user
- [ ] Create a new factsheet
- [ ] Verify ALL fields are editable (title, program name, degree type, etc.)
- [ ] Save as draft
- [ ] Verify all fields remain editable while in draft status
- [ ] Publish the factsheet
- [ ] Edit the published factsheet
- [ ] Verify restricted fields are now disabled

### Administrator Access
- [ ] Log in as administrator
- [ ] Create, edit, publish factsheets
- [ ] Verify no restrictions apply at any post status
### EAM Access now Factsheet team
- [ ] Set access to Roles or Users, select roles/users, click Update, reload – selection persists.
- [ ] Edit a factsheet that previously had EAM users/roles – same assignments appear in the new UI.
- [ ] Add more users to an existing EAM-assigned factsheet, save, reload – full list persists.
- [ ] As a non-admin team member: can edit, cannot delete.
- [ ] As a non-admin non-member: cannot edit.
- [ ] Loader appears briefly, then the “Search and select users” (and roles) UI appears.