### PR TITLE
Feat/busola/refactor

### DIFF
--- a/css/30-factsheets.css
+++ b/css/30-factsheets.css
@@ -1,0 +1,605 @@
+
+.degree-list {
+	text-align: left;
+}
+
+.degree-list li {
+	border-bottom: 1px solid #cecece;
+	width: 100%;
+	display: flex;
+}
+
+.degree-list li:after,
+.flexalign:after {
+	content: "";
+	flex-grow: 1;
+	order: 0;
+}
+
+.degree-list .pagination a {
+	width: 25px;
+	height: 25px;
+	border: 1px solid #cecece;
+	padding: 5px;
+	font-weight: 700;
+	color: #333;
+	display: inline-flex;
+	justify-content: center;
+	margin-bottom: 5px;
+	text-align: center;
+	text-decoration: none;
+}
+
+.degree-list .pagination a.active {
+	background-color: #94192b;
+	color: #fff;
+}
+
+.bigletter {
+	border-radius: 50%;
+	width: 60px;
+	height: 60px;
+	border: 1px solid #cecece;
+	color: #cecece;
+	text-align: center;
+	flex-direction: column;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 25px;
+	font-weight: 700;
+}
+
+.bigletter.active {
+	color: #94192b;
+}
+
+.bigletterline {
+	width: calc(100% - 60px);
+	border-bottom: 1px solid #cecece;
+	margin-left: 61px;
+	transform: translateY(-30px);
+}
+
+.lettergroup {
+	margin-top: 20px;
+}
+
+.lettergroup:first-of-type {
+	margin-top: 40px;
+}
+
+.lettergroup ul {
+	margin-left: 75px;
+}
+
+
+.degree-programs-header {
+	height: 190px;
+	background-color: #f7f7f9;
+	color: linear-gradient(to left, #ed6615, #880202, #880202);
+}
+
+.degree-programs-header h1 {
+	font: 300 50px/45px "Open Sans", "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", sans-serif;
+	background: -webkit-linear-gradient(135deg, #ed6615, #880202);
+	background-clip: text;
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent;
+}
+
+.degree-search-section {
+	height: 80px;
+	background-color: #eff0f2;
+	display: flex;
+	align-items: center;
+}
+
+.degree-search-section .column {
+	width: 100%;
+}
+
+#degree-search-input {
+	border: none;
+	font-size: 25px;
+	width: 100%;
+	background: #eff0f2 url(./images/search-gry.png) no-repeat left 14px;
+	background-size: 16px;
+	padding-left: 36px;
+	outline-width: 0;
+}
+
+.overlay {
+	width: 100%;
+	height: 100vh;
+	background-color: rgba(0, 0, 0, .8);
+	z-index: 99999;
+	top: 0;
+	position: fixed;
+	visibility: hidden;
+	opacity: 0;
+	transition: visibility 0s, opacity .2s linear;
+}
+
+body.searching .overlay {
+	visibility: visible;
+	opacity: 1;
+}
+
+body.searching .degree-search-section {
+	z-index: 100000;
+}
+
+.ui-autocomplete {
+	z-index: 100000;
+	background: #efefef;
+	margin-top: 1.5em;
+	padding: 1em;
+}
+
+.ui-menu-item {
+	cursor: pointer;
+	color: #717171;
+	list-style-type: none;
+	margin-top: 5px;
+}
+
+.ui-menu-item a {
+	color: #717171;
+	list-style-type: none;
+	margin-top: 5px;
+	padding: 1em;
+}
+
+.ui-corner-all {
+	width: 100%;
+	display: inline-block;
+	padding-top: .5em;
+}
+
+.ui-menu-item .ui-state-highlight {
+	color: #222;
+}
+
+.ui-state-focus {
+	background: #ccc;
+	border: none;
+	color: #000;
+	border-radius: 0;
+}
+
+.post-type-archive-gs-factsheet main ul li a:before,
+.post-type-archive-gs-factsheet main ul li a:after,
+.post-type-archive-gs-factsheet main ul li:before,
+.post-type-archive-gs-factsheet main .pagination a:before,
+.post-type-archive-gs-factsheet main .pagination a:after {
+	display: none;
+}
+
+.degree-list ul li {
+	margin-left: 0;
+	padding: 0;
+}
+
+.degree-list li.degree-row-wrapper {
+	display: inline-block;
+}
+
+.degree-row-open .degree-classification,
+.degree-row-bottom {
+	display: none;
+}
+
+.degree-row-open .degree-row-bottom .degree-classification {
+	display: block;
+}
+
+.degree-row-top,
+.degree-row-open .degree-row-bottom {
+	display: flex;
+	flex-flow: row;
+}
+
+.degree-row-multiple .degree-row-top {
+	cursor: pointer;
+}
+
+.degree-row-bottom {
+	margin-top: 1em;
+	margin-left: 2em;
+}
+
+.degree-row-bottom ~ .degree-row-bottom {
+	margin-top: 0;
+}
+
+.degree-name,
+.degree-detail {
+	order: 1;
+	flex-grow: 1;
+	padding: .5em 0 0;
+	line-height: 38px;
+}
+
+.degree-name .degree-anchor {
+	color: #ab0d24;
+	transition-property: color, background;
+	transition-duration: .4s, .4s;
+}
+
+.degree-name .degree-anchor:hover {
+	color: #b7203d;
+}
+
+.degree-caret {
+	display: inline-block;
+	margin-right: 0.5em;
+	color: #999;
+	font-weight: 700;
+	vertical-align: middle;
+	width: 1em;
+	text-align: center;
+	font-size: 0.85em;
+}
+
+.degree-link-icon {
+	display: inline-block;
+	margin-right: 0.5em;
+	color: #ab0d24;
+	font-weight: 700;
+	vertical-align: middle;
+	width: 1em;
+	text-align: center;
+	font-size: 0.85em;
+}
+
+.degree-classification {
+	order: 2;
+	flex-basis: 40px;
+	height: 40px;
+	line-height: 40px;
+	width: 40px;
+	font-weight: 700;
+	background: #ef6615;
+	border-radius: 50%;
+	color: #fff;
+	margin-left: 8px;
+	text-transform: uppercase;
+	text-align: center;
+	font-size: 19px;
+}
+
+.degree-classification:hover {
+	cursor: default;
+}
+
+.doctorate {
+	background: #931a2b;
+	padding: 0;
+}
+
+.other {
+	background: #5e6a71;
+}
+
+.graduate-certificate {
+	background: #00889d; 
+}
+
+.administrator-credentials{
+	background: #002D61; 
+}
+
+.professional-masters {
+	background: #8e44ad;
+}
+
+.masters-4plus1 {
+	background: #27ae60;
+}
+
+.key-group {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 1.5em;
+	margin-top: 1.5em;
+	margin-bottom: 1.5em;
+	max-width: 800px;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.key-classification {
+	display: flex;
+	align-items: center;
+	gap: 0.75em;
+	justify-content: space-between;
+	padding: 0.75em 1em;
+	background: #f8f9fa;
+	border: 1px solid #e9ecef;
+	border-radius: 8px;
+	transition: all 0.2s ease;
+	cursor: pointer;
+}
+
+.key-classification:hover {
+	background: #e9ecef;
+	border-color: #dee2e6;
+	transform: translateY(-1px);
+	box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.key-classification.filter-active {
+	background: #007cba;
+	border-color: #007cba;
+	color: white;
+}
+
+.key-classification.filter-active span {
+	color: white;
+}
+
+.key-classification span {
+	font-weight: 500;
+	font-size: 14px;
+	color: #495057;
+	flex: 1;
+}
+
+.key-classification .degree-classification {
+	flex-shrink: 0;
+}
+
+.filter-helper-text {
+	text-align: center;
+	margin: 1.5em 0;
+	padding: 1em;
+	background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+	border: 1px solid #dee2e6;
+	border-radius: 8px;
+	max-width: 600px;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.filter-helper-text p {
+	margin: 0;
+	color: #495057;
+	font-size: 14px;
+	font-weight: 500;
+}
+
+@media screen and (max-width: 768px) {
+	.key-group {
+		grid-template-columns: 1fr;
+		gap: 1em;
+		margin: 1em 0;
+		max-width: 100%;
+	}
+	
+	.key-classification {
+		padding: 0.5em 0.75em;
+	}
+	
+	.filter-helper-text {
+		margin: 1em 0;
+		padding: 0.75em;
+	}
+
+	.lettergroup ul {
+		margin-left: 11px;
+		margin-top: 0;
+	}
+
+	.degree-list .degree-name {
+		max-width: 79%;
+		margin-right: 5px;
+		display: flex;
+		justify-content: center;
+	}
+
+	.degree-list li .other,
+	.degree-list li .graduate-certificate,
+	.degree-list li .masters,
+	.degree-list li .professional-masters,
+	.degree-list li .masters-4plus1,
+	.degree-list li .doctorate, 
+	.degree-list li .administrator-credentials {
+		margin: auto 3px;
+	}
+
+	.degree-list li {
+		min-height: 45px;
+	}
+}
+
+/* === DEGREE FILTERING ENHANCEMENTS === */
+/* Filter button enhancements */
+.degree-list .key-classification {
+	transition: all .3s ease;
+	position: relative;
+}
+
+.degree-list .key-classification:hover {
+	transform: translateY(-2px);
+	cursor: pointer;
+}
+
+.degree-list .key-classification:hover .degree-classification {
+	box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+	transform: scale(1.05);
+}
+
+.degree-list .key-classification.filter-active {
+	transform: translateY(-2px);
+}
+
+.degree-list .key-classification.filter-active .degree-classification {
+	box-shadow: 0 6px 16px rgba(0,0,0,0.3);
+	transform: scale(1.1);
+	border: 2px solid #fff;
+	box-sizing: border-box;
+	line-height: 36px;
+}
+
+.degree-list .key-classification.filter-active::after {
+	content: '✓';
+	position: absolute;
+	top: -5px;
+	right: -5px;
+	background: #fff;
+	color: #28a745;
+	border-radius: 50%;
+	width: 20px;
+	height: 20px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 12px;
+	font-weight: bold;
+	box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+	z-index: 10;
+}
+
+/* Enhanced degree classification badges */
+.degree-list .degree-classification {
+	transition: all .3s ease;
+}
+
+/* Filter indicator styling */
+.filter-indicator {
+	background: linear-gradient(135deg,#f8f9fa,#e9ecef);
+	border: 2px solid #ca1237;
+	border-radius: 8px;
+	padding: 12px 16px;
+	margin-bottom: 1.5rem;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	box-shadow: 0 2px 8px rgba(202,18,55,0.1);
+}
+
+.filter-indicator span {
+	font-weight: 600;
+	color: #ca1237;
+	font-size: 1.1rem;
+}
+
+.clear-filter-btn {
+	background: #ca1237;
+	color: white;
+	border: none;
+	padding: 6px 12px;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: .9rem;
+	font-weight: 500;
+	transition: background-color .2s ease;
+}
+
+.clear-filter-btn:hover {
+	background: #a60f2d;
+}
+
+/* Animation for filtered rows */
+.degree-row-multiple {
+	transition: opacity .3s ease, transform .3s ease;
+}
+
+.degree-row-multiple[style*="none"] {
+	opacity: 0;
+	transform: translateY(-10px);
+}
+
+/* Letter groups animation */
+.lettergroup {
+	transition: opacity .3s ease;
+}
+
+.lettergroup[style*="none"] {
+	opacity: 0;
+}
+
+/* Add tooltips for better UX */
+.degree-list .key-classification:hover::before {
+	content: 'Click to filter • Double-click to clear';
+	position: absolute;
+	bottom: -35px;
+	left: 50%;
+	transform: translateX(-50%);
+	background: rgba(0,0,0,0.8);
+	color: white;
+	padding: 4px 8px;
+	border-radius: 4px;
+	font-size: 11px;
+	white-space: nowrap;
+	z-index: 1000;
+	opacity: 0;
+	animation: tooltipFadeIn .3s ease forwards;
+}
+
+@keyframes tooltipFadeIn {
+	from {
+		opacity: 0;
+		transform: translateX(-50%) translateY(-5px);
+	}
+	
+	to {
+		opacity: 1;
+		transform: translateX(-50%) translateY(0);
+	}
+}
+
+/* Responsive adjustments for mobile */
+@media screen and (max-width: 700px) {
+	.filter-indicator {
+		flex-direction: column;
+		text-align: center;
+	}
+	
+	.degree-list .key-classification:hover::before {
+		display: none;
+	/* Hide tooltips on mobile */
+	}
+	
+	.degree-list .key-classification.filter-active::after {
+		top: -3px;
+		right: -3px;
+		width: 16px;
+		height: 16px;
+		font-size: 10px;
+	}
+}
+
+/* Enhanced degree classification colors to match 30-factsheets.css */
+.degree-list .masters {
+	background: linear-gradient(135deg,#ef6615,#d85a12) !important;
+}
+
+.degree-list .doctorate {
+	background: linear-gradient(135deg,#931a2b,#7a1624) !important;
+}
+
+.degree-list .graduate-certificate {
+	background: linear-gradient(135deg,#00889d,#007085) !important;
+}
+
+.degree-list .administrator-credentials {
+	background: linear-gradient(135deg,#002D61,#002050) !important;
+	color: #fff !important;
+}
+
+.degree-list .other {
+	background: linear-gradient(135deg,#5e6a71,#4f595f) !important;
+	color: #fff !important;
+}
+
+.degree-list .professional-masters {
+	background: linear-gradient(135deg,#8e44ad,#7d3c98) !important;
+	color: #fff !important;
+}
+
+.degree-list .masters-4plus1 {
+	background: linear-gradient(135deg,#27ae60,#229954) !important;
+	color: #fff !important;
+}

--- a/css/factsheet-admin.css
+++ b/css/factsheet-admin.css
@@ -202,6 +202,72 @@ input[name="gsdp_program_handbook_url"], input[name="gsdp_student_learning_outco
 	color: #0073aa;
 }
 
+	/* Restricted contributor: disable title, permalink, Program Names, Degree Types */
+	body.gsdp-restricted-contributor #titlewrap input#title {
+		pointer-events: none;
+		background-color: #f0f0f0;
+		color: #666;
+		cursor: not-allowed;
+	}
+
+	body.gsdp-restricted-contributor #edit-slug-box,
+	body.gsdp-restricted-contributor #edit-slug-buttons,
+	body.gsdp-restricted-contributor .edit-slug {
+		pointer-events: none;
+		opacity: 0.5;
+	}
+
+	body.gsdp-restricted-contributor #edit-slug-buttons {
+		display: none;
+	}
+
+	body.gsdp-restricted-contributor #gs-program-namediv {
+		pointer-events: none;
+		opacity: 0.5;
+	}
+
+	body.gsdp-restricted-contributor #gs-program-namediv .inside {
+		background-color: #f0f0f0;
+	}
+
+	body.gsdp-restricted-contributor #gs-program-namediv input,
+	body.gsdp-restricted-contributor #gs-program-namediv select,
+	body.gsdp-restricted-contributor #gs-program-namediv button {
+		cursor: not-allowed;
+	}
+
+	body.gsdp-restricted-contributor #tagsdiv-gs-degree-type {
+		pointer-events: none;
+		opacity: 0.5;
+	}
+
+	body.gsdp-restricted-contributor #tagsdiv-gs-degree-type .inside {
+		background-color: #f0f0f0;
+	}
+
+	body.gsdp-restricted-contributor #tagsdiv-gs-degree-type input,
+	body.gsdp-restricted-contributor #tagsdiv-gs-degree-type select,
+	body.gsdp-restricted-contributor #tagsdiv-gs-degree-type button {
+		cursor: not-allowed;
+	}
+
+	/* EAM / Factsheet Team panel disabled for non-admins */
+	body.gsdp-eam-disabled #gsdp-team-members {
+		pointer-events: none;
+		opacity: 0.5;
+	}
+
+	body.gsdp-eam-disabled #gsdp-team-members .inside {
+		background-color: #f0f0f0;
+	}
+
+	body.gsdp-eam-disabled #gsdp-team-members input,
+	body.gsdp-eam-disabled #gsdp-team-members select,
+	body.gsdp-eam-disabled #gsdp-team-members button {
+		cursor: not-allowed;
+	}
+
+
 @media screen and (max-width: 1200px) {
 
 	.factsheet-float input,

--- a/css/factsheet-team.css
+++ b/css/factsheet-team.css
@@ -1,0 +1,377 @@
+/* =================================================================
+   Editorial Access Manager – Factsheet Team meta box
+   A polished, modern UI that fits within WordPress admin.
+   Custom multi-select (no external JS).
+   ================================================================= */
+
+#gsdp-eam-wrap {
+	padding: 4px 0 0;
+}
+
+/* Hide native multi-selects until JS replaces them (avoids flash of unstyled/native control) */
+#gsdp_team_roles,
+#gsdp_team_members {
+	position: absolute !important;
+	left: -9999px !important;
+	width: 1px !important;
+	height: 1px !important;
+	clip: rect(0, 0, 0, 0);
+	opacity: 0;
+	pointer-events: none;
+}
+
+
+/* Loader shown until custom widget is built */
+.gsdp-multiselect-loader {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 12px;
+	min-height: 42px;
+	background: #f6f7f7;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	color: #50575e;
+	font-size: 13px;
+}
+
+.gsdp-multiselect-loader-spinner {
+	display: inline-block;
+	width: 18px;
+	height: 18px;
+	border: 2px solid #c3c4c7;
+	border-top-color: #2271b1;
+	border-radius: 50%;
+	animation: gsdp-spin 0.7s linear infinite;
+}
+
+.gsdp-multiselect-loader-text {
+	opacity: 0.85;
+}
+
+@keyframes gsdp-spin {
+	to { transform: rotate(360deg); }
+}
+
+/* -----------------------------------------------------------------
+   Status badge
+   ----------------------------------------------------------------- */
+
+.gsdp-eam-status {
+	margin-bottom: 12px;
+}
+
+.gsdp-eam-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 10px;
+	border-radius: 12px;
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1.4;
+}
+
+.gsdp-eam-badge .dashicons {
+	font-size: 14px;
+	width: 14px;
+	height: 14px;
+	line-height: 14px;
+}
+
+.gsdp-eam-badge--off {
+	background: #f0f0f1;
+	color: #787c82;
+}
+
+.gsdp-eam-badge--active {
+	background: #e6f2e8;
+	color: #1e7e34;
+}
+
+/* -----------------------------------------------------------------
+   Segmented-control mode selector
+   ----------------------------------------------------------------- */
+
+.gsdp-eam-modes {
+	display: flex;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+	overflow: hidden;
+	margin-bottom: 14px;
+}
+
+.gsdp-eam-mode-btn {
+	flex: 1;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 3px;
+	padding: 7px 4px;
+	margin: 0;
+	background: #f6f7f7;
+	border: none;
+	border-right: 1px solid #c3c4c7;
+	color: #50575e;
+	font-size: 12px;
+	font-weight: 500;
+	cursor: pointer;
+	transition: background 0.15s, color 0.15s;
+	line-height: 1;
+}
+
+.gsdp-eam-mode-btn:last-child {
+	border-right: none;
+}
+
+.gsdp-eam-mode-btn:hover {
+	background: #e8eaed;
+	color: #1d2327;
+}
+
+.gsdp-eam-mode-btn.active {
+	background: #2271b1;
+	color: #fff;
+}
+
+.gsdp-eam-mode-btn .dashicons {
+	font-size: 15px;
+	width: 15px;
+	height: 15px;
+	line-height: 15px;
+}
+
+/* -----------------------------------------------------------------
+   Tabs
+   ----------------------------------------------------------------- */
+
+#gsdp-eam-tabs {
+	display: flex;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	border-bottom: 1px solid #c3c4c7;
+}
+
+#gsdp-eam-tabs li {
+	margin: 0;
+}
+
+#gsdp-eam-tabs li a {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 8px 12px;
+	color: #50575e;
+	text-decoration: none;
+	font-size: 13px;
+	font-weight: 500;
+	border-bottom: 2px solid transparent;
+	transition: color 0.15s, border-color 0.15s;
+	cursor: pointer;
+}
+
+#gsdp-eam-tabs li a:hover {
+	color: #2271b1;
+}
+
+#gsdp-eam-tabs li.active a {
+	color: #2271b1;
+	border-bottom-color: #2271b1;
+	font-weight: 600;
+}
+
+.gsdp-eam-count {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 18px;
+	height: 18px;
+	padding: 0 5px;
+	border-radius: 9px;
+	background: #dcdcde;
+	color: #50575e;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1;
+}
+
+#gsdp-eam-tabs li.active .gsdp-eam-count {
+	background: #2271b1;
+	color: #fff;
+}
+
+/* -----------------------------------------------------------------
+   Tab panels
+   ----------------------------------------------------------------- */
+
+#gsdp-eam-panels {
+	border: 1px solid #c3c4c7;
+	border-radius: 0 0 4px 4px;
+	border-top: none;
+	background: #fff;
+}
+
+.gsdp-eam-tab-panel {
+	padding: 10px;
+}
+
+/* -----------------------------------------------------------------
+   Custom multi-select widget (Chosen-like UI, no Chosen dependency)
+   ----------------------------------------------------------------- */
+
+.gsdp-multiselect {
+	position: relative;
+	display: block;
+	width: 100%;
+	font-size: 13px;
+	box-sizing: border-box;
+}
+
+.gsdp-multiselect-inner {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 4px;
+	min-height: 34px;
+	padding: 4px 6px;
+	border: 1px solid #c3c4c7;
+	border-radius: 3px;
+	background: #fff;
+	cursor: text;
+}
+
+.gsdp-multiselect.is-open .gsdp-multiselect-inner {
+	border-color: #2271b1;
+	box-shadow: 0 0 0 1px #2271b1;
+}
+
+.gsdp-multiselect-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	align-items: center;
+}
+
+.gsdp-multiselect-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 8px;
+	border: 1px solid #c3c4c7;
+	border-radius: 3px;
+	background: #f0f0f1;
+	color: #1d2327;
+	font-size: 12px;
+	line-height: 1.3;
+}
+
+.gsdp-multiselect-chip.is-disabled {
+	background: #e8eaed;
+	color: #50575e;
+	padding-right: 8px;
+}
+
+.gsdp-multiselect-chip-remove {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	margin: 0;
+	margin-left: 2px;
+	width: 16px;
+	height: 16px;
+	border: none;
+	background: none;
+	color: #787c82;
+	font-size: 16px;
+	line-height: 1;
+	cursor: pointer;
+	border-radius: 2px;
+}
+
+.gsdp-multiselect-chip-remove:hover {
+	color: #d63638;
+	background: rgba(0, 0, 0, 0.05);
+}
+
+.gsdp-multiselect-search-wrap {
+	flex: 1;
+	min-width: 80px;
+}
+
+.gsdp-multiselect-search {
+	width: 100%;
+	min-width: 80px;
+	padding: 4px 6px;
+	margin: 0;
+	border: none;
+	background: transparent;
+	font-size: 13px;
+	color: #1d2327;
+	outline: none;
+	box-sizing: border-box;
+}
+
+.gsdp-multiselect-search::placeholder {
+	color: #787c82;
+}
+
+.gsdp-multiselect-dropdown {
+	display: none;
+	position: absolute;
+	top: 100%;
+	left: 0;
+	right: 0;
+	z-index: 1010;
+	margin-top: -1px;
+	border: 1px solid #c3c4c7;
+	border-top: none;
+	border-radius: 0 0 3px 3px;
+	background: #fff;
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+	max-height: 200px;
+	overflow: hidden;
+}
+
+.gsdp-multiselect.is-open .gsdp-multiselect-dropdown {
+	display: block;
+}
+
+.gsdp-multiselect-results {
+	margin: 0;
+	padding: 4px 0;
+	list-style: none;
+	max-height: 200px;
+	overflow-y: auto;
+}
+
+.gsdp-multiselect-results li {
+	margin: 0;
+	padding: 6px 10px;
+	font-size: 13px;
+	line-height: 1.4;
+	cursor: pointer;
+}
+
+.gsdp-multiselect-results li[data-value]:hover {
+	background: #f0f0f1;
+}
+
+.gsdp-multiselect-results li.is-selected {
+	background: #e5f5fa;
+	color: #1d2327;
+}
+
+.gsdp-multiselect-results li.is-disabled {
+	color: #787c82;
+	cursor: default;
+}
+
+.gsdp-multiselect-no-results {
+	padding: 8px 10px !important;
+	color: #787c82;
+	font-style: italic;
+	cursor: default !important;
+	background: #f6f7f7 !important;
+}

--- a/includes/factsheet-team.php
+++ b/includes/factsheet-team.php
@@ -249,6 +249,9 @@ class Factsheet_Team {
 	 * @param \WP_Post $post    Post object.
 	 */
 	public static function save_team_members( $post_id, $post ) {
+		if ( ! \current_user_can( 'manage_options' ) ) {
+			return;
+		}
 		if ( \defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}

--- a/includes/factsheet-team.php
+++ b/includes/factsheet-team.php
@@ -30,6 +30,8 @@ class Factsheet_Team {
 		add_filter( 'eam_post_types', array( __CLASS__, 'exclude_from_eam' ) );
 
 		add_filter( 'map_meta_cap', array( __CLASS__, 'map_meta_cap' ), 150, 4 );
+		add_action( 'transition_post_status', array( __CLASS__, 'enable_team_access_on_publish' ), 10, 3 );
+
 	}
 
 	/**
@@ -41,6 +43,42 @@ class Factsheet_Team {
 	public static function exclude_from_eam( $post_types ) {
 		unset( $post_types[ self::POST_TYPE ] );
 		return $post_types;
+	}
+
+	/**
+	 * When a factsheet is published, enable team access with the post author as the only team member
+	 * if EAM/team access is not already configured.
+	 *
+	 * @param string   $new_status New post status.
+	 * @param string   $old_status Old post status.
+	 * @param \WP_Post $post       Post object.
+	 */
+	public static function enable_team_access_on_publish( $new_status, $old_status, $post ) {
+		
+		if ( 'publish' !== $new_status ) {
+			return;
+		}
+		// the EAM is turned on only on the transition into publish and not on every save
+		if ( $old_status === 'publish' ) {
+			return;
+		}
+
+		if ( ! $post || self::POST_TYPE !== \get_post_type( $post ) ) {
+			return;
+		}
+
+		if ( 'off' !== self::get_access_mode( $post->ID ) ) {
+			return;
+		}
+
+		$author_id = (int) $post->post_author;
+		$member_ids = $author_id > 0 ? array( $author_id ) : array();
+
+		\update_post_meta( $post->ID, self::META_KEY_MODE, 'users' );
+		\update_post_meta( $post->ID, 'eam_enable_custom_access', 'users' );
+
+		\update_post_meta( $post->ID, self::META_KEY_MEMBERS, $member_ids );
+		\update_post_meta( $post->ID, 'eam_allowed_users', $member_ids );
 	}
 
 	// ------------------------------------------------------------------

--- a/includes/factsheet-team.php
+++ b/includes/factsheet-team.php
@@ -1,0 +1,531 @@
+<?php
+
+namespace WSUWP\Plugin\Graduate;
+
+/**
+ * Manages team member assignment for factsheets.
+ *
+ * Replaces the dependency on the Editorial Access Manager (EAM) plugin
+ * for controlling which users can edit specific factsheets. The UI
+ * uses an Off / Roles / Users mode selector and a WordPress-style
+ * tabbed panel (matching the Program Names taxonomy box) with Chosen.js
+ * multi-selects for roles and users.
+ *
+ * @since 1.3.0
+ */
+class Factsheet_Team {
+
+	const META_KEY_MODE    = 'gsdp_team_access_mode';
+	const META_KEY_ROLES   = 'gsdp_team_roles';
+	const META_KEY_MEMBERS = 'gsdp_team_members';
+	const NONCE_ACTION     = 'gsdp_save_team';
+	const NONCE_NAME       = '_gsdp_team_nonce';
+	const POST_TYPE        = 'gs-factsheet';
+
+	public static function init() {
+		add_action( 'add_meta_boxes', array( __CLASS__, 'add_meta_box' ) );
+		add_action( 'save_post_' . self::POST_TYPE, array( __CLASS__, 'save_team_members' ), 10, 2 );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+
+		add_filter( 'eam_post_types', array( __CLASS__, 'exclude_from_eam' ) );
+
+		add_filter( 'map_meta_cap', array( __CLASS__, 'map_meta_cap' ), 150, 4 );
+	}
+
+	/**
+	 * Remove factsheets from EAM's managed post types.
+	 *
+	 * @param array $post_types Post types managed by EAM.
+	 * @return array
+	 */
+	public static function exclude_from_eam( $post_types ) {
+		unset( $post_types[ self::POST_TYPE ] );
+		return $post_types;
+	}
+
+	// ------------------------------------------------------------------
+	// Meta box
+	// ------------------------------------------------------------------
+
+	public static function add_meta_box() {
+		\add_meta_box(
+			'gsdp-team-members',
+			__( 'Editorial Access Manager', 'wsuwp-plugin-graduate-school' ),
+			array( __CLASS__, 'render_meta_box' ),
+			self::POST_TYPE,
+			'side',
+			'default'
+		);
+	}
+
+	/**
+	 * Render the meta box.
+	 *
+	 * Layout:
+	 *   1. Status badge showing current access state
+	 *   2. Segmented-control mode selector (Off / Roles / Users)
+	 *   3. Tabbed panel with Chosen.js multi-selects
+	 *
+	 * @param \WP_Post $post Current post object.
+	 */
+	public static function render_meta_box( $post ) {
+		global $wp_roles;
+
+		$mode            = self::get_access_mode( $post->ID );
+		$selected_roles  = self::get_team_role_slugs( $post->ID );
+		$selected_users  = self::get_team_member_ids( $post->ID );
+		$available_roles = self::get_editable_roles_for_post_type();
+		$available_users = self::get_eligible_users();
+
+		$roles_active = ( 'roles' === $mode );
+		$users_active = ( 'users' === $mode );
+
+		$roles_count = count( $selected_roles );
+		$users_count = count( $selected_users );
+
+		\wp_nonce_field( self::NONCE_ACTION, self::NONCE_NAME );
+		?>
+		<div id="gsdp-eam-wrap">
+
+			<!-- Status badge -->
+			<div class="gsdp-eam-status">
+				<?php if ( 'off' === $mode ) : ?>
+					<span class="gsdp-eam-badge gsdp-eam-badge--off">
+						<span class="dashicons dashicons-unlock"></span>
+						<?php esc_html_e( 'Open access', 'wsuwp-plugin-graduate-school' ); ?>
+					</span>
+				<?php elseif ( 'roles' === $mode ) : ?>
+					<span class="gsdp-eam-badge gsdp-eam-badge--active">
+						<span class="dashicons dashicons-groups"></span>
+						<?php
+						printf(
+							/* translators: %d: number of roles */
+							esc_html( _n( '%d role assigned', '%d roles assigned', $roles_count, 'wsuwp-plugin-graduate-school' ) ),
+							$roles_count
+						);
+						?>
+					</span>
+				<?php else : ?>
+					<span class="gsdp-eam-badge gsdp-eam-badge--active">
+						<span class="dashicons dashicons-admin-users"></span>
+						<?php
+						printf(
+							/* translators: %d: number of users */
+							esc_html( _n( '%d user assigned', '%d users assigned', $users_count, 'wsuwp-plugin-graduate-school' ) ),
+							$users_count
+						);
+						?>
+					</span>
+				<?php endif; ?>
+			</div>
+
+			<!-- Segmented-control mode selector -->
+			<div class="gsdp-eam-modes">
+				<button type="button" class="gsdp-eam-mode-btn<?php echo 'off' === $mode ? ' active' : ''; ?>" data-mode="off">
+					<span class="dashicons dashicons-no-alt"></span> <?php esc_html_e( 'Off', 'wsuwp-plugin-graduate-school' ); ?>
+				</button>
+				<button type="button" class="gsdp-eam-mode-btn<?php echo 'roles' === $mode ? ' active' : ''; ?>" data-mode="roles">
+					<span class="dashicons dashicons-groups"></span> <?php esc_html_e( 'Roles', 'wsuwp-plugin-graduate-school' ); ?>
+				</button>
+				<button type="button" class="gsdp-eam-mode-btn<?php echo 'users' === $mode ? ' active' : ''; ?>" data-mode="users">
+					<span class="dashicons dashicons-admin-users"></span> <?php esc_html_e( 'Users', 'wsuwp-plugin-graduate-school' ); ?>
+				</button>
+				<input type="hidden" name="gsdp_team_access_mode" id="gsdp_team_access_mode" value="<?php echo esc_attr( $mode ); ?>" />
+			</div>
+
+			<!-- Tabbed panel -->
+			<div id="gsdp-eam-panels" <?php echo 'off' === $mode ? 'style="display:none;"' : ''; ?>>
+
+				<ul id="gsdp-eam-tabs">
+					<li<?php echo $roles_active ? ' class="active"' : ''; ?>>
+						<a href="#gsdp-team-panel-roles">
+							<?php esc_html_e( 'Roles', 'wsuwp-plugin-graduate-school' ); ?>
+							<span class="gsdp-eam-count" id="gsdp-eam-roles-count"><?php echo (int) $roles_count; ?></span>
+						</a>
+					</li>
+					<li<?php echo $users_active ? ' class="active"' : ''; ?>>
+						<a href="#gsdp-team-panel-users">
+							<?php esc_html_e( 'Users', 'wsuwp-plugin-graduate-school' ); ?>
+							<span class="gsdp-eam-count" id="gsdp-eam-users-count"><?php echo (int) $users_count; ?></span>
+						</a>
+					</li>
+				</ul>
+
+				<!-- Roles tab panel -->
+				
+				<div id="gsdp-team-panel-roles" class="gsdp-eam-tab-panel" <?php echo ! $roles_active ? 'style="display:none;"' : ''; ?>>
+					<div class="gsdp-multiselect-loader" aria-hidden="true">
+						<span class="gsdp-multiselect-loader-spinner"></span>
+						<span class="gsdp-multiselect-loader-text"><?php esc_html_e( 'Loading…', 'wsuwp-plugin-graduate-school' ); ?></span>
+					</div>
+					<select multiple name="gsdp_team_roles[]" id="gsdp_team_roles">
+						<?php foreach ( $available_roles as $role_slug => $role_name ) : ?>
+							<option
+								value="<?php echo esc_attr( $role_slug ); ?>"
+								<?php if ( 'administrator' === $role_slug ) : ?>selected disabled
+								<?php elseif ( in_array( $role_slug, $selected_roles, true ) ) : ?>selected<?php endif; ?>
+							>
+								<?php echo esc_html( $role_name ); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+				</div>
+
+				<!-- Users tab panel -->
+				<div id="gsdp-team-panel-users" class="gsdp-eam-tab-panel" <?php echo ! $users_active ? 'style="display:none;"' : ''; ?>>
+					<div class="gsdp-multiselect-loader" aria-hidden="true">
+						<span class="gsdp-multiselect-loader-spinner"></span>
+						<span class="gsdp-multiselect-loader-text"><?php esc_html_e( 'Loading…', 'wsuwp-plugin-graduate-school' ); ?></span>
+					</div>
+					<select multiple name="gsdp_team_members[]" id="gsdp_team_members">
+						<?php foreach ( $available_users as $user_object ) :
+							$user     = new \WP_User( $user_object->ID );
+							$is_admin = in_array( 'administrator', $user->roles, true );
+							?>
+							<option
+								value="<?php echo absint( $user_object->ID ); ?>"
+								<?php if ( $is_admin ) : ?>selected disabled
+								<?php elseif ( in_array( (int) $user_object->ID, $selected_users, true ) ) : ?>selected<?php endif; ?>
+							>
+								<?php echo esc_attr( $user->user_login ); ?>
+							</option>
+						<?php endforeach; ?>
+					</select>
+				</div>
+
+			</div>
+
+		</div>
+		<?php
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers for the meta box
+	// ------------------------------------------------------------------
+
+	/**
+	 * Return role_slug => translated role name for roles with edit_posts.
+	 *
+	 * @return array
+	 */
+	private static function get_editable_roles_for_post_type() {
+		global $wp_roles;
+
+		$post_type_object = \get_post_type_object( self::POST_TYPE );
+		$edit_posts_cap   = $post_type_object ? $post_type_object->cap->edit_posts : 'edit_posts';
+		$roles            = \get_editable_roles();
+		$result           = array();
+
+		foreach ( $roles as $role_slug => $role_data ) {
+			$role = \get_role( $role_slug );
+			if ( $role && $role->has_cap( $edit_posts_cap ) ) {
+				$result[ $role_slug ] = \translate_user_role( $wp_roles->roles[ $role_slug ]['name'] );
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Return all users registered in the system (for EAM user assignment).
+	 *
+	 * @return \WP_User[]
+	 */
+	private static function get_eligible_users() {
+		return \get_users( array(
+			'orderby' => 'user_login',
+			'order'   => 'ASC',
+		) );
+	}
+
+	// ------------------------------------------------------------------
+	// Persist
+	// ------------------------------------------------------------------
+
+	/**
+	 * Save the access mode, allowed roles, and team member IDs.
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object.
+	 */
+	public static function save_team_members( $post_id, $post ) {
+		if ( \defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( 'auto-draft' === $post->post_status ) {
+			return;
+		}
+
+		if ( ! isset( $_POST[ self::NONCE_NAME ] ) || ! \wp_verify_nonce( $_POST[ self::NONCE_NAME ], self::NONCE_ACTION ) ) {
+			return;
+		}
+
+		if ( ! \current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		// Access mode.
+		$mode = isset( $_POST['gsdp_team_access_mode'] ) ? \sanitize_text_field( $_POST['gsdp_team_access_mode'] ) : 'off';
+
+		if ( ! in_array( $mode, array( 'off', 'roles', 'users' ), true ) ) {
+			$mode = 'off';
+		}
+
+		\update_post_meta( $post_id, self::META_KEY_MODE, $mode );
+
+		if ( 'off' === $mode ) {
+			\delete_post_meta( $post_id, 'eam_enable_custom_access' );
+		} else {
+			\update_post_meta( $post_id, 'eam_enable_custom_access', $mode );
+		}
+
+		// Roles — save when mode is 'roles', preserve existing when mode is 'users'.
+		if ( 'roles' === $mode ) {
+			$role_slugs = array();
+			if ( ! empty( $_POST['gsdp_team_roles'] ) && is_array( $_POST['gsdp_team_roles'] ) ) {
+				$role_slugs = array_map( 'sanitize_text_field', $_POST['gsdp_team_roles'] );
+			}
+			\update_post_meta( $post_id, self::META_KEY_ROLES, $role_slugs );
+			\update_post_meta( $post_id, 'eam_allowed_roles', $role_slugs );
+		} elseif ( 'off' === $mode ) {
+			\delete_post_meta( $post_id, self::META_KEY_ROLES );
+		}
+
+		// Users — save when mode is 'users', preserve existing when mode is 'roles'.
+		if ( 'users' === $mode ) {
+			$member_ids = array();
+			if ( ! empty( $_POST['gsdp_team_members'] ) && is_array( $_POST['gsdp_team_members'] ) ) {
+				$member_ids = array_map( 'absint', $_POST['gsdp_team_members'] );
+				$member_ids = array_values( array_unique( array_filter( $member_ids ) ) );
+			}
+			\update_post_meta( $post_id, self::META_KEY_MEMBERS, $member_ids );
+			\update_post_meta( $post_id, 'eam_allowed_users', $member_ids );
+		} elseif ( 'off' === $mode ) {
+			\delete_post_meta( $post_id, self::META_KEY_MEMBERS );
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Admin assets
+	// ------------------------------------------------------------------
+
+	public static function enqueue_assets( $hook_suffix ) {
+		if ( ! in_array( $hook_suffix, array( 'post.php', 'post-new.php' ), true ) ) {
+			return;
+		}
+
+		$screen = \get_current_screen();
+
+		if ( ! $screen || self::POST_TYPE !== $screen->id ) {
+			return;
+		}
+
+		// Plugin styles & script (custom multi-select, no external JS).
+		
+		\wp_enqueue_script(
+			'gsdp-team',
+			Plugin::get( 'url' ) . 'js/factsheet-team.js',
+			array( 'jquery' ),
+			Plugin::get( 'version' ),
+			true
+		);
+
+		\wp_enqueue_style(
+			'gsdp-team',
+			Plugin::get( 'url' ) . 'css/factsheet-team.css',
+			array(),
+			Plugin::get( 'version' )
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// Public API – reading access state
+	// ------------------------------------------------------------------
+
+	/**
+	 * Get the access mode for a factsheet.
+	 *
+	 * Falls back to EAM data when the new key has not been saved yet.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string 'off', 'roles', or 'users'.
+	 */
+	public static function get_access_mode( $post_id ) {
+		$mode = \get_post_meta( $post_id, self::META_KEY_MODE, true );
+
+		if ( in_array( $mode, array( 'off', 'roles', 'users' ), true ) ) {
+			return $mode;
+		}
+
+		// Backward compatibility with EAM.
+		$eam = \get_post_meta( $post_id, 'eam_enable_custom_access', true );
+
+		if ( in_array( $eam, array( 'roles', 'users' ), true ) ) {
+			return $eam;
+		}
+
+		return 'off';
+	}
+
+	/**
+	 * Get the allowed role slugs for a factsheet.
+	 *
+	 * Falls back to EAM data when the new key has not been saved yet.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return string[] Array of role slugs.
+	 */
+	public static function get_team_role_slugs( $post_id ) {
+		$roles = \get_post_meta( $post_id, self::META_KEY_ROLES, true );
+
+		if ( ! empty( $roles ) && is_array( $roles ) ) {
+			return $roles;
+		}
+
+		// Backward compatibility with EAM.
+		$eam_roles = \get_post_meta( $post_id, 'eam_allowed_roles', true );
+
+		if ( ! empty( $eam_roles ) && is_array( $eam_roles ) ) {
+			return $eam_roles;
+		}
+
+		return array();
+	}
+
+	/**
+	 * Get team member IDs for a factsheet.
+	 *
+	 * Falls back to EAM data when the new key has not been saved yet.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return int[] Array of user IDs.
+	 */
+	public static function get_team_member_ids( $post_id ) {
+		$members = \get_post_meta( $post_id, self::META_KEY_MEMBERS, true );
+
+		if ( ! empty( $members ) && is_array( $members ) ) {
+			return array_map( 'intval', $members );
+		}
+
+		// Backward compatibility with EAM.
+		$eam_access = \get_post_meta( $post_id, 'eam_enable_custom_access', true );
+
+		if ( 'users' === $eam_access ) {
+			$eam_users = (array) \get_post_meta( $post_id, 'eam_allowed_users', true );
+			return array_map( 'intval', array_filter( $eam_users ) );
+		}
+
+		return array();
+	}
+
+	/**
+	 * Whether team-based access control is active for a factsheet.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	public static function has_team_access( $post_id ) {
+		return 'off' !== self::get_access_mode( $post_id );
+	}
+
+	/**
+	 * Whether the given user is a team member on a factsheet
+	 * (considering both 'roles' and 'users' modes).
+	 *
+	 * @param int $user_id User ID.
+	 * @param int $post_id Post ID.
+	 * @return bool
+	 */
+	public static function is_team_member( $user_id, $post_id ) {
+		$mode = self::get_access_mode( $post_id );
+
+		if ( 'users' === $mode ) {
+			$members = self::get_team_member_ids( $post_id );
+			return in_array( (int) $user_id, $members, true );
+		}
+
+		if ( 'roles' === $mode ) {
+			$allowed_roles = self::get_team_role_slugs( $post_id );
+			$user          = new \WP_User( $user_id );
+
+			return ! empty( $user->roles ) && count( array_intersect( $user->roles, $allowed_roles ) ) > 0;
+		}
+
+		return false;
+	}
+
+	// ------------------------------------------------------------------
+	// Capability mapping
+	// ------------------------------------------------------------------
+
+	/**
+	 * Controls edit and delete capabilities for factsheets based on
+	 * team membership.
+	 *
+	 * When team access is active:
+	 *  - Team members (non-admin) may edit but NOT delete.
+	 *  - Non-team, non-admin users are denied edit access.
+	 *  - Administrators always retain full access.
+	 *
+	 * @param string[] $caps    Primitive caps required.
+	 * @param string   $cap     Capability being checked.
+	 * @param int      $user_id User ID.
+	 * @param array    $args    Additional arguments (post ID, etc.).
+	 * @return string[]
+	 */
+	public static function map_meta_cap( $caps, $cap, $user_id, $args ) {
+		$edit_caps   = array( 'edit_post', 'edit_page', 'edit_others_posts', 'edit_others_pages', 'publish_posts', 'publish_pages' );
+		$delete_caps = array( 'delete_post', 'delete_page' );
+
+		if ( ! in_array( $cap, array_merge( $edit_caps, $delete_caps ), true ) ) {
+			return $caps;
+		}
+
+		$post_id = isset( $args[0] ) ? (int) $args[0] : null;
+
+		if ( ! $post_id && ! empty( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$post_id = (int) $_GET['post'];
+		}
+
+		if ( ! $post_id && ! empty( $_POST['post_ID'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$post_id = (int) $_POST['post_ID'];
+		}
+
+		if ( ! $post_id ) {
+			return $caps;
+		}
+
+		if ( self::POST_TYPE !== \get_post_type( $post_id ) ) {
+			return $caps;
+		}
+
+		if ( ! self::has_team_access( $post_id ) ) {
+			return $caps;
+		}
+
+		$user = new \WP_User( $user_id );
+
+		if ( in_array( 'administrator', $user->roles, true ) ) {
+			return $caps;
+		}
+
+		$is_member = self::is_team_member( $user_id, $post_id );
+
+		if ( in_array( $cap, $delete_caps, true ) ) {
+			if ( $is_member ) {
+				$caps[] = 'do_not_allow';
+			}
+		} else {
+			if ( $is_member ) {
+				$caps = array();
+			} else {
+				$caps[] = 'do_not_allow';
+			}
+		}
+
+		return $caps;
+	}
+}
+
+Factsheet_Team::init();

--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -24,6 +24,16 @@ class Plugin {
 	}
 
 
+
+	public static function init() {
+
+		require_once __DIR__ . '/shortcode.php';
+
+		require_once __DIR__ . '/single.php';
+
+	}
+
+
 	public static function load_class( $slug ) {
 
 		require_once self::get( 'dir' ) . "classes/class-{$slug}.php";
@@ -34,3 +44,5 @@ class Plugin {
 
 
 }
+
+Plugin::init();

--- a/includes/plugin.php
+++ b/includes/plugin.php
@@ -27,6 +27,8 @@ class Plugin {
 
 	public static function init() {
 
+		require_once __DIR__ . '/factsheet-team.php';
+
 		require_once __DIR__ . '/shortcode.php';
 
 		require_once __DIR__ . '/single.php';

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -1,0 +1,269 @@
+<?php namespace WSUWP\Plugin\Graduate;
+
+class Shortcode {
+	
+	public static function init() {
+
+		add_shortcode( 'gsdegrees', array( __CLASS__, 'add_gs_shortcodes' ) );
+
+	}
+
+	/**
+	 * Sort degree classifications in the specified order.
+	 *
+	 * @since 1.1.29
+	 *
+	 * @param array $classifications Array of classification strings.
+	 * @return array Sorted array of classifications.
+	 */
+	protected static function sort_classifications( $classifications ) {
+		$order = array(
+			'doctorate',
+			'masters',
+			'professional-masters',
+			'masters-4plus1',
+			'graduate-certificate',
+			'administrator-credentials',
+		);
+
+		usort( $classifications, function( $a, $b ) use ( $order ) {
+			$pos_a = array_search( $a, $order );
+			$pos_b = array_search( $b, $order );
+
+			// If not found in order array, put at end
+			if ( false === $pos_a ) {
+				$pos_a = 999;
+			}
+			if ( false === $pos_b ) {
+				$pos_b = 999;
+			}
+
+			return $pos_a - $pos_b;
+		} );
+
+		return $classifications;
+	}
+
+	/**
+	 * Enqueue frontend scripts and styles when shortcode is used.
+	 *
+	 * @since 1.1.24
+	 */
+	public static function enqueue_frontend_scripts() {
+		// This will be called by the shortcode when needed
+		wp_enqueue_style( 
+			'wsuwp-graduate-factsheets', 
+			Plugin::get( 'url' ) . '/css/30-factsheets.css', 
+			array(), 
+			WSUWPPLUGINGRADUATEVERSION 
+		);
+		
+		wp_enqueue_script( 
+			'wsuwp-graduate-factsheets-az', 
+			Plugin::get( 'url' ) . '/js/factsheet-az.min.js', 
+			array(), 
+			WSUWPPLUGINGRADUATEVERSION, 
+			true 
+		);
+	}
+
+
+	public static function add_gs_shortcodes( $atts, $content = '' ) {
+
+		// Enqueue the CSS when shortcode is used
+		self::enqueue_frontend_scripts();
+
+		$factsheets = self::get_fact_sheets( $atts );
+
+		ob_start();
+
+		include Plugin::get( 'dir' ) . '/templates/az-index.php';
+
+		$html_content = ob_get_clean();
+
+		wp_reset_postdata();
+
+		return $html_content;
+
+	}
+
+
+	protected static function get_fact_sheets( $atts = array() ) {
+
+		$factsheets = array();
+		$all_entries = array(); // Collect all entries first
+		
+		$gradfair = isset( $atts['gradfair'] ) && $atts['gradfair'];
+
+		$query_args = array(
+			'post_type'      => 'gs-factsheet',
+			'posts_per_page' => -1,
+			'orderby'        => 'title',
+			'order'          => 'ASC',
+		);
+
+		if ( ! empty( $_REQUEST['degree-search'] ) ) {
+
+			$query_args['s'] = sanitize_term_field( $_REQUEST['degree-search'] );
+		}
+
+
+		$the_query = new \WP_Query( $query_args );
+
+		if ( $the_query->have_posts() ) {
+
+			while ( $the_query->have_posts() ) {
+
+				$the_query->the_post();
+
+				$factsheet_data = \WSUWP_Graduate_Degree_Programs::get_factsheet_data( get_the_ID() );
+
+				if ( 'No' === $factsheet_data['public'] ) {
+					continue;
+				}
+		
+				$factsheet_data['permalink'] = get_the_permalink();
+		
+				if ( $gradfair ) {
+					$factsheet_data['permalink'] = str_replace( '/degrees/factsheet/', '/wsugradfair/degrees/factsheet/', $factsheet_data['permalink'] );
+				}
+		
+			$degree_types = wp_get_object_terms( get_the_ID(), 'gs-degree-type' );
+			$program_name = wp_get_object_terms( get_the_ID(), 'gs-program-name' );
+
+			// Get program name once (used for all degree types)
+			if ( ! is_wp_error( $program_name ) && 0 < count( $program_name ) ) {
+				$program_name_value = $program_name[0]->name;
+			} else {
+				$program_name_value = '';
+			}
+
+			// Get factsheet key once (used for all degree types)
+			if ( ! empty( $factsheet_data['shortname'] ) ) {
+				$factsheet_key = $factsheet_data['shortname'];
+			} else {
+				$factsheet_key = get_the_title();
+			}
+
+			// Process each degree type and collect all entries
+			if ( ! is_wp_error( $degree_types ) && 0 < count( $degree_types ) ) {
+				foreach ( $degree_types as $degree_type ) {
+					$degree_classification = get_term_meta( $degree_type->term_id, 'gs_degree_type_classification', true );
+					
+					if ( empty( $degree_classification ) ) {
+						$degree_classification = 'other';
+					}
+					
+					$entry = $factsheet_data;
+					$entry['degree_type'] = $degree_type->name;
+					$entry['program_name'] = $program_name_value;
+					$entry['degree_classification'] = $degree_classification;
+					$entry['factsheet_key'] = $factsheet_key;
+					
+					$all_entries[] = $entry;
+				}
+			} else {
+				// Fallback for factsheets with no degree types
+				$factsheet_data['degree_type'] = 'Other';
+				$factsheet_data['program_name'] = $program_name_value;
+				$factsheet_data['degree_classification'] = 'other';
+				$factsheet_data['factsheet_key'] = $factsheet_key;
+				$all_entries[] = $factsheet_data;
+			}
+
+			}
+
+		}
+
+		// Group entries by program name first
+		$grouped_by_program = array();
+		foreach ( $all_entries as $entry ) {
+			$group_key = $entry['factsheet_key'];
+			if ( ! isset( $grouped_by_program[ $group_key ] ) ) {
+				$grouped_by_program[ $group_key ] = array();
+			}
+			$grouped_by_program[ $group_key ][] = $entry;
+		}
+		
+		// Now process each program group
+		foreach ( $grouped_by_program as $program_key => $program_entries ) {
+			$masters_entries = array();
+			$non_masters_entries = array();
+			
+			// Separate masters from non-masters for this program
+			foreach ( $program_entries as $entry ) {
+				if ( in_array( $entry['degree_classification'], array( 'masters', 'professional-masters', 'masters-4plus1' ) ) ) {
+					$masters_entries[] = $entry;
+				} else {
+					$non_masters_entries[] = $entry;
+				}
+			}
+			
+			// Create grouped masters entry if there are any masters degrees
+			if ( ! empty( $masters_entries ) ) {
+				$grouped_masters = $masters_entries[0]; // Use first as base
+				$classifications = array_column( $masters_entries, 'degree_classification' );
+				$grouped_masters['degree_classifications'] = self::sort_classifications( $classifications );
+				$grouped_masters['degree_types'] = array_column( $masters_entries, 'degree_type' );
+				$grouped_masters['degree_classification'] = 'masters';
+				$grouped_masters['degree_type'] = 'Masters'; // Always use generic "Masters" for grouped entries
+				
+				$factsheets[ $program_key ][] = $grouped_masters;
+			}
+			
+			// Add non-masters entries
+			foreach ( $non_masters_entries as $entry ) {
+				$factsheets[ $program_key ][] = $entry;
+			}
+			
+			// Sort all entries in this factsheet by classification order
+			if ( isset( $factsheets[ $program_key ] ) && is_array( $factsheets[ $program_key ] ) ) {
+				usort( $factsheets[ $program_key ], function( $a, $b ) {
+					$order = array(
+						'doctorate',
+						'masters',
+						'professional-masters',
+						'masters-4plus1',
+						'graduate-certificate',
+						'administrator-credentials',
+					);
+					
+					// For grouped masters, use the first (highest priority) classification from sorted array
+					if ( isset( $a['degree_classifications'] ) && is_array( $a['degree_classifications'] ) && ! empty( $a['degree_classifications'] ) ) {
+						$class_a = $a['degree_classifications'][0];
+					} else {
+						$class_a = $a['degree_classification'];
+					}
+					
+					if ( isset( $b['degree_classifications'] ) && is_array( $b['degree_classifications'] ) && ! empty( $b['degree_classifications'] ) ) {
+						$class_b = $b['degree_classifications'][0];
+					} else {
+						$class_b = $b['degree_classification'];
+					}
+					
+					$pos_a = array_search( $class_a, $order );
+					$pos_b = array_search( $class_b, $order );
+					
+					// If not found in order array, put at end
+					if ( false === $pos_a ) {
+						$pos_a = 999;
+					}
+					if ( false === $pos_b ) {
+						$pos_b = 999;
+					}
+					
+					return $pos_a - $pos_b;
+				} );
+			}
+		}
+
+		ksort( $factsheets );
+
+		return $factsheets;
+
+
+	}
+
+}
+
+Shortcode::init();

--- a/includes/single.php
+++ b/includes/single.php
@@ -1,0 +1,35 @@
+<?php namespace WSUWP\Plugin\Graduate;
+
+class Single{
+	
+	public static function init() {
+
+		add_filter( 'the_content', array( __CLASS__, 'display_fact_sheet' ), 9 );
+
+	}
+
+
+	public static function display_fact_sheet( $content ) {
+
+        remove_filter( 'the_content', array( __CLASS__, 'display_fact_sheet' ), 9 );
+
+        if ( is_main_query() && is_singular( 'gs-factsheet' ) ) {
+
+            $factsheet_data = \WSUWP_Graduate_Degree_Programs::get_factsheet_data( get_the_id() );
+
+            ob_start();
+
+            include Plugin::get( 'dir' ) . '/templates/factsheet.php';
+
+            $content = ob_get_clean();
+
+        }
+		
+		return $content;
+
+
+	}
+
+}
+
+Single::init();

--- a/js/factsheet-admin.min.js
+++ b/js/factsheet-admin.min.js
@@ -66,5 +66,17 @@
       factsheetPrimaryInputs.on("click", ".remove-factsheet-requirements-field", function (event) {
       $(event.target).parent(".factsheet-requirements-field").remove();
     });
+    	/* Restricted contributor: disable title, permalink, Program Names, Degree Types */
+    if ($('body').hasClass('gsdp-restricted-contributor')) {
+      $("#title").prop("readonly", true);
+      $("#edit-slug-buttons .edit-slug").remove();
+      $(".edit-slug").remove();
+      $("#gs-program-namediv input, #gs-program-namediv select, #gs-program-namediv button").prop("disabled", true);
+      $("#tagsdiv-gs-degree-type input, #tagsdiv-gs-degree-type select, #tagsdiv-gs-degree-type button").prop("disabled", true);
+    }
+    /* EAM panel disabled for non-admins */
+    if ($('body').hasClass('gsdp-eam-disabled')) {
+      $("#gsdp-team-members input, #gsdp-team-members select, #gsdp-team-members button").prop("disabled", true);
+    }
   
   })(jQuery, window);

--- a/js/factsheet-az.min.js
+++ b/js/factsheet-az.min.js
@@ -1,0 +1,429 @@
+document.addEventListener('DOMContentLoaded', function() {
+    initDegreeFiltering();
+    initDegreeExpansion();
+    initPagination();
+    diagnoseDegreeStructure();
+  });
+
+  function initDegreeExpansion() {
+    const degreeAnchors = document.querySelectorAll('.degree-anchor');
+    
+    degreeAnchors.forEach(anchor => {
+      anchor.style.cursor = 'pointer';
+      
+      anchor.addEventListener('click', function() {
+        const rowWrapper = this.closest('.degree-row-wrapper');
+        if (!rowWrapper) return;
+        
+        // Toggle the expanded state
+        const isExpanded = rowWrapper.classList.contains('degree-row-open');
+        
+        if (isExpanded) {
+          rowWrapper.classList.remove('degree-row-open');
+        } else {
+          rowWrapper.classList.add('degree-row-open');
+        }
+        
+        // Update caret - show state after toggle
+        const caret = rowWrapper.querySelector('.degree-caret');
+        if (caret) {
+          // After toggle: if now expanded, show down; if now collapsed, show right
+          if (rowWrapper.classList.contains('degree-row-open')) {
+            caret.textContent = '▼';
+          } else {
+            caret.textContent = '▶';
+          }
+        }
+        
+        // Remove any inline display styles from bottom rows to let CSS handle it
+        const bottomRows = rowWrapper.querySelectorAll('.degree-row-bottom');
+        bottomRows.forEach(bottomRow => {
+          bottomRow.style.display = '';
+        });
+      });
+    });
+  }
+
+  function diagnoseDegreeStructure() {
+    // Target ALL degree rows, not just multiple ones
+    const degreeRows = document.querySelectorAll('.degree-row-wrapper');
+  
+    degreeRows.forEach((row, index) => {
+      if (index < 5) {
+        // Check for classification badges in both top and bottom sections
+        const badges = row.querySelectorAll('.degree-classification');
+      }
+    });
+  
+    const filterButtons = document.querySelectorAll('.key-classification');
+  
+    filterButtons.forEach((button, index) => {
+      const badge = button.querySelector('.degree-classification');
+    });
+  
+    const letterGroups = document.querySelectorAll('.lettergroup');
+  }
+
+function initDegreeFiltering() {
+  const filterButtons = document.querySelectorAll('.key-classification');
+
+  if (!filterButtons.length) {
+    return;
+  }
+
+  filterButtons.forEach((button, index) => {
+    button.style.cursor = 'pointer';
+
+    button.addEventListener('click', function() {
+      const classificationElement = this.querySelector('.degree-classification');
+      if (!classificationElement) {
+        return;
+      }
+
+      let filterType = null;
+      if (classificationElement.classList.contains('masters')) {
+        filterType = 'masters';
+      } else if (classificationElement.classList.contains('professional-masters')) {
+        filterType = 'professional-masters';
+      } else if (classificationElement.classList.contains('masters-4plus1')) {
+        filterType = 'masters-4plus1';
+      } else if (classificationElement.classList.contains('doctorate')) {
+        filterType = 'doctorate';
+      } else if (classificationElement.classList.contains('graduate-certificate')) {
+        filterType = 'graduate-certificate';
+      } else if (classificationElement.classList.contains('administrator-credentials')) {
+        filterType = 'administrator-credentials';
+      } else if (classificationElement.classList.contains('other')) {
+        filterType = 'other';
+      }
+
+      const isCurrentlyActive = this.classList.contains('filter-active');
+      
+      // Get the button label text
+      const buttonLabel = this.querySelector('span');
+      const filterLabel = buttonLabel ? buttonLabel.textContent.trim() : null;
+
+      filterButtons.forEach(btn => btn.classList.remove('filter-active'));
+
+      if (!isCurrentlyActive && filterType) {
+        this.classList.add('filter-active');
+        filterDegrees(filterType, filterLabel);
+      } else {
+        clearFilter();
+      }
+    });
+  });
+
+  // Double-click to clear filters
+  filterButtons.forEach(button => {
+    button.addEventListener('dblclick', function() {
+      filterButtons.forEach(btn => btn.classList.remove('filter-active'));
+      clearFilter();
+    });
+  });
+}
+
+function filterDegrees(filterType, filterLabel = null) {
+  // Target ALL degree row wrappers, not just multiple ones
+  const degreeRows = document.querySelectorAll('.degree-row-wrapper');
+  const letterGroups = document.querySelectorAll('.lettergroup');
+
+  let visibleCount = 0;
+
+  degreeRows.forEach((row, index) => {
+    // Check if any classification badge in this row matches the filter
+    const classificationBadges = row.querySelectorAll('.degree-classification');
+    let hasMatchingClassification = false;
+
+      classificationBadges.forEach(badge => {
+        let matchesFilter = false;
+        
+        // When filtering by "masters", show all masters types
+        if (filterType === 'masters') {
+          matchesFilter = badge.classList.contains('masters') || 
+                         badge.classList.contains('professional-masters') || 
+                         badge.classList.contains('masters-4plus1');
+        } else {
+          // For specific filters (professional-masters, masters-4plus1), only show exact matches
+          matchesFilter = badge.classList.contains(filterType);
+        }
+        
+        if (matchesFilter) {
+          hasMatchingClassification = true;
+        }
+      });
+
+      if (hasMatchingClassification) {
+        row.style.display = 'block';
+        
+        // Hide all badges in the top row when filtering
+        const degreeRowTop = row.querySelector('.degree-row-top');
+        if (degreeRowTop) {
+          const topRowBadges = degreeRowTop.querySelectorAll('.degree-classification');
+          topRowBadges.forEach(badge => {
+            badge.style.display = 'none';
+          });
+        }
+        
+        // Hide degree-row-bottom elements that contain non-matching classifications
+        const degreeRowBottoms = row.querySelectorAll('.degree-row-bottom');
+        degreeRowBottoms.forEach(bottomRow => {
+          const bottomBadges = bottomRow.querySelectorAll('.degree-classification');
+          let matchesFilter = false;
+          
+          // Check all badges in the bottom row
+          bottomBadges.forEach(bottomBadge => {
+            let badgeMatches = false;
+            
+            // When filtering by "masters", show all masters types
+            if (filterType === 'masters') {
+              badgeMatches = bottomBadge.classList.contains('masters') || 
+                             bottomBadge.classList.contains('professional-masters') || 
+                             bottomBadge.classList.contains('masters-4plus1');
+            } else {
+              // For specific filters (professional-masters, masters-4plus1), only show exact matches
+              badgeMatches = bottomBadge.classList.contains(filterType);
+            }
+            
+            if (badgeMatches) {
+              matchesFilter = true;
+            }
+          });
+          
+          if (matchesFilter) {
+            bottomRow.style.display = 'flex';
+          } else {
+            bottomRow.style.display = 'none';
+          }
+        });
+        
+        visibleCount++;
+      } else {
+        row.style.display = 'none';
+      }
+  });
+
+  updateLetterGroups();
+  
+  // Hide general degree name rows when filter is active and there are grouped entries
+  hideGeneralDegreeRowsWhenFiltered();
+  
+  showFilterFeedback(filterType, filterLabel);
+}
+
+function hideGeneralDegreeRowsWhenFiltered() {
+  // Keep degree names visible - no longer hiding the top row
+  // This function is kept for potential future use but currently does nothing
+}
+
+function clearFilter() {
+  // Target ALL degree row wrappers
+  const degreeRows = document.querySelectorAll('.degree-row-wrapper');
+  const letterGroups = document.querySelectorAll('.lettergroup');
+
+  degreeRows.forEach(row => {
+    // Reset row visibility
+    row.style.display = 'block';
+    
+    // Reset all classification badges
+    const classificationBadges = row.querySelectorAll('.degree-classification');
+    classificationBadges.forEach(badge => {
+      badge.style.display = 'block';
+    });
+    
+    // Reset degree-row-top sections
+    const degreeRowTop = row.querySelector('.degree-row-top');
+    if (degreeRowTop) {
+      degreeRowTop.style.display = 'flex';
+      degreeRowTop.style.flexFlow = 'row';
+    }
+    
+    // Reset degree-row-bottom elements - remove inline styles so CSS can control visibility
+    const degreeRowBottoms = row.querySelectorAll('.degree-row-bottom');
+    degreeRowBottoms.forEach(bottomRow => {
+      // Remove inline display style to let CSS handle it based on degree-row-open class
+      bottomRow.style.display = '';
+    });
+  });
+
+  // Reset letter groups visibility
+  letterGroups.forEach(group => {
+    group.style.display = 'block';
+  });
+
+  // Remove filter feedback indicator
+  removeFilterFeedback();
+}
+
+  function updateLetterGroups() {
+    const letterGroups = document.querySelectorAll('.lettergroup');
+  
+    letterGroups.forEach(group => {
+      // Check for ALL degree row wrappers in this group
+      const degreeRows = group.querySelectorAll('.degree-row-wrapper');
+  
+      const hasVisibleDegrees = Array.from(degreeRows).some(row =>
+        !row.style.display || row.style.display !== 'none'
+      );
+  
+      if (hasVisibleDegrees) {
+        group.style.display = 'block';
+      } else {
+        group.style.display = 'none';
+      }
+    });
+  }
+
+function showFilterFeedback(filterType, filterLabel) {
+  removeFilterFeedback();
+
+  const displayText = filterLabel || getFilterDisplayName(filterType);
+  
+  const indicator = document.createElement('div');
+  indicator.className = 'filter-indicator';
+  indicator.innerHTML = `
+        <span>Showing: ${displayText}</span>
+        <button type="button" class="clear-filter-btn">Clear Filters</button>
+    `;
+
+  // Add some basic styling
+  indicator.style.cssText = `
+        background: linear-gradient(135deg, #e3f2fd 0%, #bbdefb 100%);
+        border: 1px solid #007cba;
+        border-radius: 8px;
+        padding: 1em 1.5em;
+        margin: 1.5em 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    `;
+
+  const clearBtn = indicator.querySelector('.clear-filter-btn');
+  clearBtn.style.cssText = `
+        background: #007cba;
+        color: white;
+        border: none;
+        padding: 0.5em 1em;
+        border-radius: 6px;
+        cursor: pointer;
+        font-size: 12px;
+        font-weight: 500;
+        transition: all 0.2s ease;
+    `;
+    
+  clearBtn.addEventListener('mouseenter', function() {
+    this.style.background = '#005a87';
+    this.style.transform = 'translateY(-1px)';
+  });
+  
+  clearBtn.addEventListener('mouseleave', function() {
+    this.style.background = '#007cba';
+    this.style.transform = 'translateY(0)';
+  });
+  
+  clearBtn.addEventListener('click', function() {
+    clearAllFiltersAndLetters();
+  });
+
+  const degreeList = document.querySelector('.degree-list');
+  if (degreeList) {
+    degreeList.insertBefore(indicator, degreeList.firstChild);
+  }
+}
+
+function removeFilterFeedback() {
+  const existing = document.querySelector('.filter-indicator');
+  if (existing) {
+    existing.remove();
+  }
+}
+
+  function getFilterDisplayName(filterType) {
+    const names = {
+      'masters': 'Master\'s Degrees (M, PM, 4+1)',
+      'professional-masters': 'Master\'s Degrees (M, PM, 4+1)',
+      'masters-4plus1': 'Master\'s Degrees (M, PM, 4+1)',
+      'doctorate': 'Doctoral Degrees',
+      'graduate-certificate': 'Graduate Certificates',
+      'administrator-credentials': 'Administrator Credentials',
+      'other': 'Other Programs'
+    };
+    return names[filterType] || filterType;
+  }
+
+function clearAllFilters() {
+  const filterButtons = document.querySelectorAll('.key-classification');
+  filterButtons.forEach(btn => btn.classList.remove('filter-active'));
+  clearFilter();
+  removeFilterFeedback();
+}
+
+function initPagination() {
+  const paginationLinks = document.querySelectorAll('.degree-list .pagination a');
+  const letterGroups = document.querySelectorAll('.lettergroup');
+  
+  if (!paginationLinks.length) {
+    return;
+  }
+  
+  // Handle click on pagination links
+  paginationLinks.forEach(link => {
+    link.addEventListener('click', function(e) {
+      e.preventDefault();
+      
+      // Remove active class from all pagination links
+      paginationLinks.forEach(l => l.classList.remove('active'));
+      
+      // Add active class to clicked link
+      this.classList.add('active');
+      
+      // Get the target letter from href
+      const targetLetter = this.getAttribute('href').substring(1);
+      
+      // Show only the selected letter group, hide all others
+      letterGroups.forEach(group => {
+        const anchor = group.querySelector('a[name]');
+        if (anchor) {
+          const letter = anchor.getAttribute('name');
+          if (letter === targetLetter) {
+            group.style.display = 'block';
+          } else {
+            group.style.display = 'none';
+          }
+        }
+      });
+      
+      // Show filter feedback for letter filter
+      showFilterFeedback(null, `Degrees beginning with ${targetLetter.toUpperCase()}`);
+    });
+  });
+}
+
+function clearAllFiltersAndLetters() {
+  // Clear degree type filters
+  const filterButtons = document.querySelectorAll('.key-classification');
+  filterButtons.forEach(btn => btn.classList.remove('filter-active'));
+  clearFilter();
+  
+  // Clear letter filters
+  const paginationLinks = document.querySelectorAll('.degree-list .pagination a');
+  const letterGroups = document.querySelectorAll('.lettergroup');
+  
+  // Reset pagination - set first letter (A) as active
+  paginationLinks.forEach((link, index) => {
+    if (index === 0) {
+      link.classList.add('active');
+    } else {
+      link.classList.remove('active');
+    }
+  });
+  
+  // Show all letter groups
+  letterGroups.forEach(group => {
+    group.style.display = 'block';
+  });
+  
+  // Remove filter feedback
+  removeFilterFeedback();
+}

--- a/js/factsheet-team.js
+++ b/js/factsheet-team.js
@@ -1,0 +1,351 @@
+(function ($) {
+	'use strict';
+
+	$(function () {
+		var $wrap        = $('#gsdp-eam-wrap');
+		var $modeInput   = $('#gsdp_team_access_mode');
+		var $modeButtons = $wrap.find('.gsdp-eam-mode-btn');
+		var $panels      = $('#gsdp-eam-panels');
+		var $tabs        = $('#gsdp-eam-tabs');
+		var $rolesSelect = $('#gsdp_team_roles');
+		var $usersSelect = $('#gsdp_team_members');
+		var $statusWrap  = $wrap.find('.gsdp-eam-status');
+		var $rolesCount  = $('#gsdp-eam-roles-count');
+		var $usersCount  = $('#gsdp-eam-users-count');
+
+		if (!$rolesSelect.length || !$usersSelect.length) {
+			return;
+		}
+
+		// ---------------------------------------------------------------
+		// Custom multi-select widget (replaces Chosen)
+		// ---------------------------------------------------------------
+
+	function buildMultiSelect($select, opts) {
+		var placeholder = opts.placeholder || 'Select...';
+		var noResultsText = opts.noResultsText || 'No results found';
+
+		$select.hide();
+
+		var $container = $('<div class="gsdp-multiselect">');
+		var $inner = $('<div class="gsdp-multiselect-inner">');
+		var $chips = $('<div class="gsdp-multiselect-chips">');
+		var $searchWrap = $('<div class="gsdp-multiselect-search-wrap">');
+		var $search = $('<input type="text" class="gsdp-multiselect-search" placeholder="' + placeholder + '" autocomplete="off">');
+		var $dropdown = $('<div class="gsdp-multiselect-dropdown">');
+		var $list = $('<ul class="gsdp-multiselect-results">');
+		var $noResults = $('<li class="gsdp-multiselect-no-results">' + noResultsText + '</li>');
+
+		$searchWrap.append($search);
+		$inner.append($chips).append($searchWrap);
+		$dropdown.append($list);
+		$container.append($inner).append($dropdown);
+		$select.after($container);
+
+		function getOptions() {
+			var items = [];
+			$select.find('option').each(function () {
+				var $opt = $(this);
+				items.push({
+					value: $opt.val(),
+					text: $opt.text(),
+					selected: $opt.prop('selected'),
+					disabled: $opt.prop('disabled')
+				});
+			});
+			return items;
+		}
+
+		function isSelected(value) {
+			value = String(value);
+			return $select.find('option[value="' + value.replace(/"/g, '\\"') + '"]').prop('selected');
+		}
+
+		function setSelected(value, selected) {
+			value = String(value);
+			var $opt = $select.find('option[value="' + value.replace(/"/g, '\\"') + '"]');
+			if ($opt.length && !$opt.prop('disabled')) {
+				$opt.prop('selected', !!selected);
+			}
+		}
+
+		function renderChips() {
+			var html = '';
+			$select.find('option:selected').each(function () {
+				var $opt = $(this);
+				var v = $opt.val();
+				var text = $opt.text();
+				var disabled = $opt.prop('disabled');
+				html += '<span class="gsdp-multiselect-chip' + (disabled ? ' is-disabled' : '') + '" data-value="' + $('<div>').text(v).html() + '">';
+				html += '<span class="gsdp-multiselect-chip-text">' + $('<div>').text(text).html() + '</span>';
+				if (!disabled) {
+					html += '<button type="button" class="gsdp-multiselect-chip-remove" aria-label="Remove">&times;</button>';
+				}
+				html += '</span>';
+			});
+			$chips.html(html);
+		}
+
+		function filterList(searchVal) {
+			searchVal = (searchVal || '').toLowerCase();
+			var visible = 0;
+			$list.find('li[data-value]').each(function () {
+				var $li = $(this);
+				var text = $li.data('text') || '';
+				var show = !searchVal || text.toLowerCase().indexOf(searchVal) !== -1;
+				$li.toggle(show);
+				if (show) visible++;
+			});
+			$list.find('.gsdp-multiselect-no-results').toggle(visible === 0);
+		}
+
+		function renderList() {
+			$list.empty();
+			var options = getOptions();
+			options.forEach(function (o) {
+				var $li = $('<li>')
+					.attr('data-value', o.value)
+					.data('text', o.text)
+					.data('disabled', o.disabled)
+					.text(o.text)
+					.toggleClass('is-selected', o.selected)
+					.toggleClass('is-disabled', o.disabled);
+				if (!o.disabled) {
+					$li.attr('tabindex', 0).css('cursor', 'pointer');
+				}
+				$list.append($li);
+			});
+			$list.append($noResults);
+			$noResults.hide();
+			filterList($search.val());
+		}
+		// Remove loader that was shown until widget was built
+		$select.prev('.gsdp-multiselect-loader').remove();
+
+		function openDropdown() {
+			$container.addClass('is-open');
+				$dropdown.show();
+			$search.focus();
+			filterList($search.val());
+		}
+
+		function closeDropdown() {
+			$container.removeClass('is-open');
+			$dropdown.hide();
+			$search.val('');
+			filterList('');
+		}
+
+		function toggleOption(value) {
+			value = String(value);
+			var $opt = $select.find('option[value="' + value.replace(/"/g, '\\"') + '"]');
+			if ($opt.length && !$opt.prop('disabled')) {
+				$opt.prop('selected', !$opt.prop('selected'));
+				renderChips();
+				renderList();
+				$select.trigger('change');
+			}
+		}
+
+		// Chips remove
+		$container.on('click', '.gsdp-multiselect-chip-remove', function (e) {
+			e.preventDefault();
+			e.stopPropagation();
+			var val = $(this).closest('.gsdp-multiselect-chip').data('value');
+			setSelected(String(val), false);
+			renderChips();
+			renderList();
+			$select.trigger('change');
+		});
+
+		// List item click
+		$list.on('click', 'li[data-value]', function (e) {
+			e.preventDefault();
+			var $li = $(this);
+			if ($li.hasClass('is-disabled')) return;
+			toggleOption($li.data('value'));
+		});
+
+		// Search
+		$search.on('input', function () {
+			filterList($(this).val());
+		});
+
+		$search.on('focus', function () {
+			openDropdown();
+		});
+
+		$inner.on('click', function (e) {
+			if (!$(e.target).closest('.gsdp-multiselect-chip-remove').length) {
+				openDropdown();
+			}
+		});
+
+		// Close on outside click
+		$(document).on('click.gsdpMultiselect', function (e) {
+			if (!$(e.target).closest($container).length) {
+				closeDropdown();
+			}
+		});
+
+		// Initial render
+		renderChips();
+		renderList();
+
+		// Re-render when select is changed programmatically
+		$select.on('change', function () {
+			renderChips();
+			renderList();
+		});
+
+		return {
+			destroy: function () {
+				$(document).off('click.gsdpMultiselect');
+				$container.remove();
+				$select.show();
+			},
+			refresh: function () {
+				renderChips();
+				renderList();
+			}
+		};
+	}
+
+	// Init custom multi-selects
+	buildMultiSelect($rolesSelect, { placeholder: 'Select roles...', noResultsText: 'No roles found matching' });
+	buildMultiSelect($usersSelect, { placeholder: 'Search and select users...', noResultsText: 'No users found matching' });
+
+	// ---------------------------------------------------------------
+	// Status badge
+	// ---------------------------------------------------------------
+
+	function updateStatus() {
+		var mode = $modeInput.val();
+		var html = '';
+
+		if (mode === 'off') {
+			html = '<span class="gsdp-eam-badge gsdp-eam-badge--off">' +
+				'<span class="dashicons dashicons-unlock"></span> Open access</span>';
+		} else if (mode === 'roles') {
+			var rc = $rolesSelect.val() ? $rolesSelect.val().length : 0;
+			html = '<span class="gsdp-eam-badge gsdp-eam-badge--active">' +
+				'<span class="dashicons dashicons-groups"></span> ' +
+				rc + (rc === 1 ? ' role' : ' roles') + ' assigned</span>';
+		} else {
+			var uc = $usersSelect.val() ? $usersSelect.val().length : 0;
+			html = '<span class="gsdp-eam-badge gsdp-eam-badge--active">' +
+				'<span class="dashicons dashicons-admin-users"></span> ' +
+				uc + (uc === 1 ? ' user' : ' users') + ' assigned</span>';
+		}
+
+		$statusWrap.html(html);
+	}
+
+	function updateCounts() {
+		var rc = $rolesSelect.val() ? $rolesSelect.val().length : 0;
+		var uc = $usersSelect.val() ? $usersSelect.val().length : 0;
+		$rolesCount.text(rc);
+		$usersCount.text(uc);
+	}
+
+	$rolesSelect.on('change', function () { updateCounts(); updateStatus(); });
+	$usersSelect.on('change', function () { updateCounts(); updateStatus(); });
+
+	// ---------------------------------------------------------------
+	// Tab switching
+	// ---------------------------------------------------------------
+
+	function activateTab(panelId) {
+		$tabs.find('li').removeClass('active');
+		$tabs.find('a[href="' + panelId + '"]').parent('li').addClass('active');
+
+		$panels.find('.gsdp-eam-tab-panel').hide();
+		$(panelId).show();
+	}
+
+	$tabs.on('click', 'a', function (e) {
+		e.preventDefault();
+		var panel = $(this).attr('href');
+		activateTab(panel);
+
+		var newMode = (panel === '#gsdp-team-panel-roles') ? 'roles' : 'users';
+		$modeInput.val(newMode);
+		$modeButtons.removeClass('active');
+		$modeButtons.filter('[data-mode="' + newMode + '"]').addClass('active');
+		updateStatus();
+	});
+
+	// ---------------------------------------------------------------
+	// Segmented-control mode buttons
+	// ---------------------------------------------------------------
+
+	$modeButtons.on('click', function () {
+		var mode = $(this).data('mode');
+		$modeInput.val(mode);
+		$modeButtons.removeClass('active');
+		$(this).addClass('active');
+
+		if (mode === 'off') {
+			$panels.slideUp(150);
+		} else {
+			$panels.slideDown(150, function () {
+				if (mode === 'roles') {
+					activateTab('#gsdp-team-panel-roles');
+				} else {
+					activateTab('#gsdp-team-panel-users');
+				}
+			});
+		}
+
+		updateStatus();
+	});
+
+	// ---------------------------------------------------------------
+	// Initial state
+	// ---------------------------------------------------------------
+
+		(function init() {
+			var mode = $modeInput.val();
+
+			if (mode === 'off') {
+				$panels.hide();
+			} else if (mode === 'roles') {
+				activateTab('#gsdp-team-panel-roles');
+			} else {
+				activateTab('#gsdp-team-panel-users');
+			}
+
+			updateCounts();
+		})();
+
+		// Before submit: inject hidden inputs so the selection is reliably
+		// included in $_POST even though the native <select> is hidden.
+		$('#post').on('submit', function () {
+			$('.gsdp-multiselect').each(function () {
+				var $container = $(this);
+				var $select = $container.prev('select');
+				if (!$select.length) {
+					return;
+				}
+
+				var fieldName = $select.attr('name');
+				if (!fieldName) {
+					return;
+				}
+
+				// Remove the name from the native select so it doesn't
+				// double-submit alongside the hidden inputs.
+				$select.removeAttr('name');
+
+				// Collect selected (non-disabled) values from the select.
+				$select.find('option:selected:not(:disabled)').each(function () {
+					$('<input type="hidden">')
+						.attr('name', fieldName)
+						.val($(this).val())
+						.appendTo($select.closest('form'));
+				});
+			});
+		});
+	});
+
+})(jQuery);

--- a/legacy/class-factsheet-access.php
+++ b/legacy/class-factsheet-access.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Factsheet access and permissions.
+ *
+ * Centralizes checks for factsheet team membership (EAM) and restricted contributors.
+ * Used by auth_post_meta filters and meta box display to restrict who can edit
+ * certain fields (e.g. degree shortname, include in programs, taxonomies).
+ *
+ * @since 1.6.0
+ */
+
+class WSUWP_Factsheet_Access {
+
+	/**
+	 * Whether the user is a team member (EAM) for the given factsheet.
+	 *
+	 * Delegates to {@see \WSUWP\Plugin\Graduate\Factsheet_Team::is_team_member()}
+	 * which also provides backward compatibility with legacy EAM post meta.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param int $user_id User ID.
+	 * @param int $post_id Post ID (factsheet).
+	 *
+	 * @return bool
+	 */
+	public static function user_is_eam_user( $user_id, $post_id ) {
+		return \WSUWP\Plugin\Graduate\Factsheet_Team::is_team_member( $user_id, $post_id );
+	}
+
+	/**
+	 * Determines if a user is a restricted contributor.
+	 *
+	 * A user is considered a restricted contributor if:
+	 * - They are assigned as a factsheet team member, OR
+	 * - They have a WordPress role of 'contributor', 'author', or 'editor' (only 'administrator' has full access)
+	 *
+	 * Restricted users cannot edit (on existing factsheets only):
+	 * - Factsheet title
+	 * - Factsheet display name
+	 * - Include in programs list
+	 * - Program Names taxonomy
+	 * - Degree Types taxonomy
+	 *
+	 * Note: No restrictions apply when creating a NEW factsheet or editing a DRAFT - all fields are editable.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param int      $user_id The user ID to check.
+	 * @param int|null $post_id Optional. The post ID for team membership check.
+	 *
+	 * @return bool True if the user is a restricted contributor, false otherwise.
+	 */
+	public static function user_is_restricted_contributor( $user_id, $post_id = null ) {
+		// No restrictions for new posts or drafts - allow full access when creating/drafting a factsheet
+		$post_status = $post_id ? get_post_status( $post_id ) : '';
+		if ( empty( $post_id ) || in_array( $post_status, array( 'auto-draft', 'draft' ), true ) ) {
+			return false;
+		}
+
+		// Check team membership (if post_id provided)
+		if ( $post_id && self::user_is_eam_user( $user_id, $post_id ) ) {
+			return true;
+		}
+
+		// Check WordPress role
+		$user = new WP_User( $user_id );
+		$restricted_roles = array( 'contributor', 'author', 'editor' );
+		$unrestricted_roles = array( 'administrator' );
+
+		foreach ( $unrestricted_roles as $role ) {
+			if ( in_array( $role, $user->roles, true ) ) {
+				return false;
+			}
+		}
+
+		foreach ( $restricted_roles as $role ) {
+			if ( in_array( $role, $user->roles, true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Auth filter: disallow restricted contributors from changing restricted meta.
+	 *
+	 * Restricted contributors include factsheet team members and users with
+	 * contributor/author/editor roles.
+	 *
+	 * @since 1.6.0
+	 *
+	 * @param bool   $allowed   Whether the user is allowed to update the meta.
+	 * @param string $meta_key  Meta key.
+	 * @param int    $object_id Post ID.
+	 * @param int    $user_id   User ID.
+	 *
+	 * @return bool
+	 */
+	public static function can_edit_restricted_field( $allowed, $meta_key, $object_id, $user_id ) {
+		if ( self::user_is_restricted_contributor( $user_id, $object_id ) ) {
+			return false;
+		}
+
+		return $allowed;
+	}
+}

--- a/legacy/class-factsheet-admin-assets.php
+++ b/legacy/class-factsheet-admin-assets.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Admin assets (CSS/JS) for the factsheet post type and degree type taxonomy.
+ *
+ * @package WSUWP_Graduate_School
+ */
+
+class WSUWP_Factsheet_Admin_Assets {
+
+	/**
+	 * Post type slug (e.g. gs-factsheet).
+	 *
+	 * @var string
+	 */
+	private $post_type_slug;
+
+	/**
+	 * Degree type taxonomy slug (e.g. gs-degree-type).
+	 *
+	 * @var string
+	 */
+	private $taxonomy_degree_type;
+
+	/**
+	 * @param string $post_type_slug       Post type slug.
+	 * @param string $taxonomy_degree_type Degree type taxonomy slug.
+	 */
+	public function __construct( $post_type_slug, $taxonomy_degree_type = 'gs-degree-type' ) {
+		$this->post_type_slug       = $post_type_slug;
+		$this->taxonomy_degree_type = $taxonomy_degree_type;
+	}
+
+	/**
+	 * Enqueue scripts and styles used in the admin for factsheets and degree types.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param string $hook_suffix Current admin page hook suffix.
+	 */
+	public function admin_enqueue_scripts( $hook_suffix ) {
+		$screen = get_current_screen();
+		if ( ! $screen ) {
+			return;
+		}
+
+		if ( in_array( $hook_suffix, array( 'post.php', 'post-new.php' ), true ) && $this->post_type_slug === $screen->id ) {
+			wp_deregister_script( 'yoast-seo-post-scraper' );
+			wp_deregister_script( 'yoast-seo-term-scraper' );
+			wp_deregister_script( 'yoast-seo-featured-image' );
+
+			wp_enqueue_style( 'gsdp-admin', WSUWP\Plugin\Graduate\Plugin::get( 'url' ) . '/css/factsheet-admin.css', array(), WSUWP_Graduate_School_Theme()->theme_version() );
+			wp_register_script( 'gsdp-factsheet-admin', WSUWP\Plugin\Graduate\Plugin::get( 'url' ) . '/js/factsheet-admin.min.js', array( 'jquery', 'underscore', 'jquery-ui-autocomplete' ), WSUWP_Graduate_School_Theme()->theme_version(), true );
+			wp_enqueue_script( 'gsdp-factsheet-admin' );
+		}
+
+		if ( in_array( $hook_suffix, array( 'edit-tags.php', 'term.php', 'term-new.php' ), true ) && $this->taxonomy_degree_type === $screen->taxonomy ) {
+			wp_enqueue_style( 'gsdp-faculty-admin', WSUWP\Plugin\Graduate\Plugin::get( 'url' ) . '/css/faculty-admin.css', array(), WSUWP_Graduate_School_Theme()->theme_version() );
+		}
+	}
+}

--- a/legacy/class-factsheet-archive.php
+++ b/legacy/class-factsheet-archive.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Factsheet archive, query vars, and menus.
+ *
+ * @package WSUWP_Graduate_School
+ */
+class WSUWP_Factsheet_Archive {
+
+	/**
+	 * Post type slug (e.g. gs-factsheet).
+	 *
+	 * @var string
+	 */
+	private $post_type_slug;
+
+	/**
+	 * @param string $post_type_slug Post type slug.
+	 */
+	public function __construct( $post_type_slug ) {
+		$this->post_type_slug = $post_type_slug;
+	}
+
+	/**
+	 * Add our custom query variable to the set of default query variables.
+	 *
+	 * @since 1.4.0
+	 *
+	 * @param array $vars
+	 *
+	 * @return array
+	 */
+	public function add_gradfair_query_var( $vars ) {
+		$vars[] = 'gradfair';
+		return $vars;
+	}
+
+	/**
+	 * Register a mirror navigation area for grad fair usage.
+	 *
+	 * @since 1.4.0
+	 */
+	public function register_mirror_menu() {
+		register_nav_menus(
+			array(
+				'gradfair' => 'WSU Grad Fair',
+			)
+		);
+	}
+
+	/**
+	 * Adjusts the archive query for factsheets to show all factsheets.
+	 *
+	 * @since 0.8.0
+	 *
+	 * @param \WP_Query $query
+	 */
+	public function adjust_factsheet_archive_query( $query ) {
+		if ( is_post_type_archive( $this->post_type_slug ) ) {
+			$query->set( 'posts_per_page', -1 );
+		}
+	}
+
+	/**
+	 * Alters the title displayed for the factsheets landing page.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $view_title
+	 * @param string $site_title
+	 * @param string $global_title
+	 *
+	 * @return string
+	 */
+	public function filter_factsheet_archive_title( $view_title, $site_title, $global_title ) {
+		if ( is_post_type_archive( $this->post_type_slug ) ) {
+			return 'Graduate Degree Programs | ' . $site_title . $global_title;
+		}
+		return $view_title;
+	}
+}

--- a/legacy/class-factsheet-data.php
+++ b/legacy/class-factsheet-data.php
@@ -1,0 +1,182 @@
+<?php
+
+class WSUWP_Factsheet_Data {
+
+/**
+	 * Returns a usable subset of data for displaying a factsheet.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param int $post_id
+	 *
+	 * @return array
+	 */
+	public static function get_factsheet_data( $post_id ) {
+		$factsheet_data = get_registered_metadata( 'post', $post_id );
+
+		$data = array(
+			'degree_id' => 0,
+			'shortname' => '',
+			'description' => '',
+			'accepting_applications' => 'No',
+			'faculty' => array(),
+			'students' => 0,
+			'aided' => 0,
+			'totalfac' => 0,
+			'totalcorefac' => 0,
+			'degree_url' => 'Not available',
+			'student_learning_outcome_url' =>'', 
+			'application_url' => 'https://gradschool.wsu.edu/apply/',
+			'handbook_url' => '',
+			'deadlines' => array(),
+			'deadlines_prog' => array(),
+			'requirements' => array(),
+			'requirements_gre' => array(),
+			'contacts' => array(),
+			'locations' => array(
+				'Pullman' => 'No',
+				'Spokane' => 'No',
+				'Tri-Cities' => 'No',
+				'Vancouver' => 'No',
+				'Everett' => 'No',
+				'Global Campus (online)' => 'No',
+			),
+			'global_URL' => '',
+			'admission_requirements',
+			'student_opportunities',
+			'career_opportunities',
+			'career_placements',
+			'student_learning_outcome',
+			'public' => 'No',
+		);
+
+		if ( isset( $factsheet_data['gsdp_degree_description'][0] ) ) {
+			$data['description'] = $factsheet_data['gsdp_degree_description'][0];
+		}
+
+		// if ( isset( $factsheet_data['gsdp_degree_id'][0] ) ) {
+		// 	$data['degree_id'] = $factsheet_data['gsdp_degree_id'][0];
+		// }
+
+		if ( isset( $factsheet_data['gsdp_include_in_programs'][0] ) && 1 === absint( $factsheet_data['gsdp_include_in_programs'][0] ) ) {
+			$data['public'] = 'Yes';
+		}
+
+		if ( isset( $factsheet_data['gsdp_degree_shortname'][0] ) ) {
+			$data['shortname'] = $factsheet_data['gsdp_degree_shortname'][0];
+		}
+
+		if ( isset( $factsheet_data['gsdp_accepting_applications'][0] ) && 1 === absint( $factsheet_data['gsdp_accepting_applications'][0] ) ) {
+			$data['accepting_applications'] = 'Yes';
+		}
+
+		if ( isset( $factsheet_data['gsdp_grad_students_total'][0] ) ) {
+			$data['students'] = $factsheet_data['gsdp_grad_students_total'][0];
+		}
+
+		if ( isset( $factsheet_data['gsdp_grad_faculty_total'][0] ) ) {
+			$data['totalfac'] = $factsheet_data['gsdp_grad_faculty_total'][0];
+		}
+
+		if ( isset( $factsheet_data['gsdp_grad_core_faculty_total'][0] ) ) {
+			$data['totalcorefac'] = $factsheet_data['gsdp_grad_core_faculty_total'][0];
+		}
+
+		if ( isset( $factsheet_data['gsdp_grad_students_total'][0] ) ) {
+			$data['students'] = $factsheet_data['gsdp_grad_students_total'][0];
+		}
+
+		if ( isset( $factsheet_data['gsdp_grad_students_aided'][0] ) ) {
+			if ( 0 === absint( $data['students'] ) ) {
+				$data['aided'] = '0.00';
+			} else {
+				$data['aided'] = $factsheet_data['gsdp_grad_students_aided'][0];
+			}
+		}
+
+		if ( isset( $factsheet_data['gsdp_degree_url'][0] ) ) {
+			$data['degree_url'] = $factsheet_data['gsdp_degree_url'][0];
+		}
+
+		if ( isset( $factsheet_data['gsdp_application_url'][0] ) ) {
+			$data['application_url'] = $factsheet_data['gsdp_application_url'][0];
+		}
+		
+
+		if ( isset( $factsheet_data['gsdp_student_learning_outcome_url'][0] ) ) {
+			$data['student_learning_outcome_url'] = $factsheet_data['gsdp_student_learning_outcome_url'][0];
+		}
+
+
+		if ( isset( $factsheet_data['gsdp_program_handbook_url'][0] ) ) {
+			$data['handbook_url'] = $factsheet_data['gsdp_program_handbook_url'][0];
+		}
+
+		if ( isset( $factsheet_data['gsdp_deadlines'][0] ) ) {
+			$data['deadlines'] = maybe_unserialize( $factsheet_data['gsdp_deadlines'][0] );
+
+			if ( ! is_array( $data['deadlines'] ) ) {
+				$data['deadlines'] = array();
+			}
+		}
+
+		if ( isset( $factsheet_data['gsdp_deadlines_prog'][0] ) ) {
+			$data['deadlines_prog'] = maybe_unserialize( $factsheet_data['gsdp_deadlines_prog'][0] );
+
+			if ( ! is_array( $data['deadlines_prog'] ) ) {
+				$data['deadlines_prog'] = array();
+			}
+		}
+
+		if ( isset( $factsheet_data['gsdp_requirements_gre'][0] ) ) {
+			$data['requirements_gre'] = maybe_unserialize( $factsheet_data['gsdp_requirements_gre'][0] );
+
+			if ( ! is_array( $data['requirements_gre'] ) ) {
+				$data['requirements_gre'] = array();
+			}
+		}
+
+		if ( isset( $factsheet_data['gsdp_requirements'][0] ) ) {
+			$data['requirements'] = maybe_unserialize( $factsheet_data['gsdp_requirements'][0] );
+
+			if ( ! is_array( $data['requirements'] ) ) {
+				$data['requirements'] = array();
+			}
+		}
+
+		if ( isset( $factsheet_data['gsdp_contacts'][0] ) ) {
+			$data['gscontacts'] = maybe_unserialize( $factsheet_data['gsdp_contacts'][0] );
+
+			if ( ! is_array( $data['gscontacts'] ) ) {
+				$data['gscontacts'] = array();
+			}
+		}
+
+		if ( isset( $factsheet_data['gsdp_locations'][0] ) ) {
+			$locations = maybe_unserialize( $factsheet_data['gsdp_locations'][0] );
+			$data['locations'] = wp_parse_args( $locations, $data['locations'] );
+		}
+
+		if ( isset( $factsheet_data['gsdp_admission_requirements'][0] ) ) {
+			$data['admission_requirements'] = $factsheet_data['gsdp_admission_requirements'][0];
+		}
+
+		if ( isset( $factsheet_data['gsdp_student_opportunities'][0] ) ) {
+			$data['student_opportunities'] = $factsheet_data['gsdp_student_opportunities'][0];
+		}
+
+		if ( isset( $factsheet_data['gsdp_career_opportunities'][0] ) ) {
+			$data['career_opportunities'] = $factsheet_data['gsdp_career_opportunities'][0];
+		}
+
+		if ( isset( $factsheet_data['gsdp_career_placements'][0] ) ) {
+			$data['career_placements'] = $factsheet_data['gsdp_career_placements'][0];
+		}
+
+		if ( isset( $factsheet_data['gsdp_global_URL'][0] ) ) {
+			$data['global_URL'] = $factsheet_data['gsdp_global_URL'][0];
+		}
+
+		return $data;
+	}
+}

--- a/legacy/class-factsheet-fields-display.php
+++ b/legacy/class-factsheet-fields-display.php
@@ -1,0 +1,628 @@
+<?php
+/**
+ * Renders factsheet meta box field HTML (primary and secondary).
+ *
+ * Used by the factsheet edit screen; receives meta config and calls
+ * display_*_meta_field per field. Permission checks use WSUWP_Factsheet_Access.
+ *
+ * @package WSUWP_Graduate_School
+ */
+
+class WSUWP_Factsheet_Fields_Display {
+
+		/**
+	 * Outputs the HTML associated with the primary and secondary meta boxes.
+	 *
+	 * @since 0.7.0
+	 *
+	 * @param $meta
+	 * @param $data
+	 * @param $key
+	 */
+	public static function output_meta_box_html( $meta, $data, $key ) {
+		if ( isset( $meta['pre_html'] ) ) {
+			echo $meta['pre_html']; // @codingStandardsIgnoreLine (HTML is static in code)
+		}
+		?>
+		<div class="factsheet-primary-input factsheet-<?php echo esc_attr( $meta['type'] ); ?>">
+		<?php
+
+		if ( isset( $meta['meta_field_callback'] ) && is_callable( $meta['meta_field_callback'] ) ) {
+			call_user_func( $meta['meta_field_callback'], $meta, $key, $data );
+		}
+
+		echo '</div>'; // End factsheet-primary-input
+
+		if ( isset( $meta['post_html'] ) ) {
+			echo $meta['post_html']; // @codingStandardsIgnoreLine (HTML is static in code)
+		}
+	}
+
+    
+
+	/**
+	 * Outputs the meta field HTML used to capture meta data stored as strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array  $meta
+	 * @param string $key
+	 * @param array  $data
+	 */
+	public static function display_string_meta_field( $meta, $key, $data ) {
+		?>
+		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
+		<?php
+
+		// Check if field is restricted and user is a restricted contributor
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
+			$disabled = 'disabled';
+		} else {
+			$disabled = '';
+		}
+
+		?>
+		<input type="text" name="<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $data[ $key ][0] ); ?>" <?php echo $disabled; // @codingStandardsIgnoreLine (HTML is static in code) ?> />
+		<?php
+	}
+
+	/**
+	 * Outputs the meta field HTML used to capture meta data stored as an integer.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array  $meta
+	 * @param string $key
+	 * @param array  $data
+	 */
+	public static function display_int_meta_field( $meta, $key, $data ) {
+		?>
+		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
+		<?php
+
+		// Check if field is restricted and user is a restricted contributor
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
+			$disabled = 'disabled';
+		} else {
+			$disabled = '';
+		}
+
+		?>
+		<input type="text" id="<?php echo esc_attr( $key ); ?>" name="<?php echo esc_attr( $key ); ?>" value="<?php echo absint( $data[ $key ][0] ); ?>" <?php echo $disabled; // @codingStandardsIgnoreLine (HTML is static in code) ?> />
+		<?php
+	}
+
+	/**
+	 * Outputs the meta field HTML used to capture meta data stored as boolean.
+	 *
+	 * @since 1.3.0
+	 * @since 1.4.0 Added support for restricted fields that are disabled for contributors.
+	 *
+	 * @param array  $meta
+	 * @param string $key
+	 * @param array  $data
+	 */
+	public static function display_bool_meta_field( $meta, $key, $data ) {
+		// Check if field is restricted and user is a restricted contributor
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
+			$disabled = 'disabled';
+		} else {
+			$disabled = '';
+		}
+
+		?>
+		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
+		<select name="<?php echo esc_attr( $key ); ?>" <?php echo $disabled; // @codingStandardsIgnoreLine ?>>
+			<option value="0" <?php selected( 0, absint( $data[ $key ][0] ) ); ?>>No</option>
+			<option value="1" <?php selected( 1, absint( $data[ $key ][0] ) ); ?>>Yes</option>
+		</select>
+		<?php
+	}
+
+	/**
+	 * Outputs the meta field HTML used to capture meta data stored as strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array  $meta
+	 * @param string $key
+	 * @param array  $data
+	 */
+	public static function display_textarea_meta_field( $meta, $key, $data ) {
+		?>
+		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
+		<?php
+
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
+			echo '<div id="' . esc_attr( $key ) . '" class="field-content">' . wp_kses_post( apply_filters( 'the_content', $data[ $key ][0] ) ) . '</div>';
+			return;
+		}
+
+		$wp_editor_settings = array(
+			'textarea_rows' => 10,
+			'media_buttons' => false,
+			'teeny' => true,
+		);
+
+		wp_editor( $data[ $key ][0], esc_attr( $key ), $wp_editor_settings );
+	}
+
+		/**
+	 * Outputs the meta field HTML used to capture meta data stored as strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array  $meta
+	 * @param string $key
+	 * @param array  $data
+	 */
+	public static function display_deadlines_prog_meta_field( $meta, $key, $data ) {
+		$field_data = maybe_unserialize( $data[ $key ][0] );
+
+		if ( empty( $field_data ) ) {
+			$field_data = array();
+		}
+
+		$default_field_data = array(
+			'semester' => 'None',
+			'deadline' => '',
+			'international' => '',
+		);
+		$field_count = 0;
+
+		?>
+		<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
+			<span class="factsheet-label"><strong>Program Deadlines:</strong></span>
+			<?php
+
+			foreach ( $field_data as $field_datum ) {
+				$field_datum = wp_parse_args( $field_datum, $default_field_data );
+
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<select name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][semester]">
+						<option value="None" <?php selected( 'None', $field_datum['semester'] ); ?>>Not selected</option>
+						<option value="Fall" <?php selected( 'Fall', $field_datum['semester'] ); ?>>Fall</option>
+						<option value="Spring" <?php selected( 'Spring', $field_datum['semester'] ); ?>>Spring</option>
+						<option value="Summer" <?php selected( 'Summer', $field_datum['semester'] ); ?>>Summer</option>
+					</select>
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][deadline]" value="<?php echo esc_attr( $field_datum['deadline'] ); ?>" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][international]" value="<?php echo esc_attr( $field_datum['international'] ); ?>" />
+					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
+				</span>
+				<?php
+				$field_count++;
+			}
+
+			// If no fields have been added, provide an empty field by default.
+			if ( 0 === count( $field_data ) ) {
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<select name="<?php echo esc_attr( $key ); ?>[0][semester]">
+						<option value="None">Not selected</option>
+						<option value="Fall">Fall</option>
+						<option value="Spring">Spring</option>
+						<option value="Summer">Summer</option>
+					</select>
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][deadline]" value="" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][international]" value="" />
+				</span>
+				<?php
+			}
+
+			// @codingStandardsIgnoreStart
+			?>
+			<script type="text/template" id="factsheet-deadlines_prog-template">
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<select name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][semester]">
+						<option value="None">Not selected</option>
+						<option value="Fall">Fall</option>
+						<option value="Spring">Spring</option>
+						<option value="Summer">Summer</option>
+					</select>
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][deadline]" value="" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][international]" value="" />
+					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
+				</span>
+			</script>
+			<input type="button" class="add-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field button" value="Add" />
+			<input type="hidden" name="factsheet_deadlines_prog_form_count" id="factsheet_deadlines_prog_form_count" value="<?php echo esc_attr( $field_count ); ?>" />
+		</div>
+		<?php
+		// @codingStandardsIgnoreEnd
+	}
+
+	/**
+	 * Outputs the meta field HTML used to capture meta data stored as strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array  $meta
+	 * @param string $key
+	 * @param array  $data
+	 */
+	public static function display_deadlines_meta_field( $meta, $key, $data ) {
+		$field_data = maybe_unserialize( $data[ $key ][0] );
+
+		if ( empty( $field_data ) ) {
+			$field_data = array();
+		}
+
+		$default_field_data = array(
+			'semester' => 'None',
+			'deadline' => '',
+			'international' => '',
+		);
+		$field_count = 0;
+
+		?>
+		<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
+			<span class="factsheet-label"><strong>Priority Deadlines:</strong></span>
+			<?php
+
+			// If no fields have been added, provide an empty field by default.
+			if ( 0 === count( $field_data ) ) {
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<select name="<?php echo esc_attr( $key ); ?>[0][semester]">
+						<option value="None">Not selected</option>
+						<option value="Fall">Fall</option>
+						<option value="Spring">Spring</option>
+						<option value="Summer">Summer</option>
+					</select>
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][deadline]" value="" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][international]" value="" />
+				</span>
+				<?php
+			}
+
+			foreach ( $field_data as $field_datum ) {
+				$field_datum = wp_parse_args( $field_datum, $default_field_data );
+
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<select name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][semester]">
+						<option value="None" <?php selected( 'None', $field_datum['semester'] ); ?>>Not selected</option>
+						<option value="Fall" <?php selected( 'Fall', $field_datum['semester'] ); ?>>Fall</option>
+						<option value="Spring" <?php selected( 'Spring', $field_datum['semester'] ); ?>>Spring</option>
+						<option value="Summer" <?php selected( 'Summer', $field_datum['semester'] ); ?>>Summer</option>
+					</select>
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][deadline]" value="<?php echo esc_attr( $field_datum['deadline'] ); ?>" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][international]" value="<?php echo esc_attr( $field_datum['international'] ); ?>" />
+					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
+				</span>
+				<?php
+				$field_count++;
+			}
+
+
+
+			// @codingStandardsIgnoreStart
+			?>
+			<script type="text/template" id="factsheet-deadline-template">
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<select name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][semester]">
+						<option value="None">Not selected</option>
+						<option value="Fall">Fall</option>
+						<option value="Spring">Spring</option>
+						<option value="Summer">Summer</option>
+					</select>
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][deadline]" value="" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][international]" value="" />
+					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
+				</span>
+			</script>
+			<input type="button" class="add-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field button" value="Add" />
+			<input type="hidden" name="factsheet_deadline_form_count" id="factsheet_deadline_form_count" value="<?php echo esc_attr( $field_count ); ?>" />
+		</div>
+		<?php
+		// @codingStandardsIgnoreEnd
+	}
+
+
+		/**
+	 * Outputs the meta field HTML used to capture meta data stored as strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array  $meta
+	 * @param string $key
+	 * @param array  $data
+	 */
+	public static function display_contacts_meta_field( $meta, $key, $data ) {
+			$field_data = maybe_unserialize( $data[ $key ][0] );
+	
+			if ( empty( $field_data ) ) {
+				$field_data = array();
+			}
+	
+			$default_field_data = array(
+				'name' => '',
+				'email' => '',
+			);
+			$field_count = 0;
+	
+			?>
+			<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
+				<span class="factsheet-label"><strong>Contact Information: </strong></span>
+				<?php
+	
+				foreach ( $field_data as $field_datum ) {
+					$field_datum = wp_parse_args( $field_datum, $default_field_data );
+	
+					?>
+					<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+						<label for="Name">Name: </label>
+						<input type="text" id="Name" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][name]" value="<?php echo esc_attr( $field_datum['name'] ); ?>" />
+						<label for="Email">Email: </label>
+						<input type="text" id ="Email" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][email]" value="<?php echo esc_attr( $field_datum['email'] ); ?>" />
+						<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
+					</span>
+					<?php
+					$field_count++;
+				}
+	
+				// If no fields have been added, provide an empty field by default.
+				if ( 0 === count( $field_data ) ) {
+					?>
+					<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<label for="Name">Name: </label>
+	
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][name]" value="" /><br>
+					<label for="Email">Email: </label>
+
+						<input type="text" name="<?php echo esc_attr( $key ); ?>[0][email]" value="" />
+					</span>
+					<?php
+				}
+	
+				// @codingStandardsIgnoreStart
+				?>
+				<script type="text/template" id="factsheet-gscontacts-template">
+					<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<label for="Name">Name: </label>
+						<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][name]" value="" />
+						<label for="Email">Email: </label>
+						<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][email]" value="" />
+						<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
+					</span>
+				</script>
+				<input type="button" class="add-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field button" value="Add" />
+				<input type="hidden" name="factsheet_gscontacts_count" id="factsheet_gscontacts_count" value="<?php echo esc_attr( $field_count ); ?>" />
+			</div>
+			<?php
+			// @codingStandardsIgnoreEnd
+		}
+	
+
+
+	/**
+	 * Outputs the meta field HTML used to capture meta data stored as strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array  $meta
+	 * @param string $key
+	 * @param array  $data
+	 */
+	public static function display_requirements_gre_meta_field( $meta, $key, $data ) {
+		$field_data = maybe_unserialize( $data[ $key ][0] );
+
+		if ( empty( $field_data ) ) {
+			$field_data = array();
+		}
+
+		$default_field_data = array(
+			'required' => 'None',
+			'test' => '',
+		);
+		$field_count = 0;
+
+		?>
+		<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
+			<span class="factsheet-label"><strong>Additional Program Requirements:</strong></span>
+			<?php
+
+			// If no fields have been added, provide an empty field by default.
+			if ( 0 === count( $field_data ) ) {
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+				<label for="test">Test Name (GRE, GMAT, etc.): </label>
+
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][test]" value="" />
+					<label for="required">Required?:  </label>
+
+					<select id="required" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][required]">
+						<option value="None" <?php selected( 'None', $default_field_data['required'] ); ?>>Not selected</option>
+						<option value="Optional" <?php selected( 'Optional', $default_field_data['required'] ); ?>>Optional</option>
+						<option value="Yes" <?php selected( 'Yes', $default_field_data['required'] ); ?>>Yes</option>
+						<option value="No" <?php selected( 'No', $default_field_data['required'] ); ?>>No</option>
+					</select>
+				</span>
+				<?php
+				}
+
+			foreach ( $field_data as $field_datum ) {
+				$field_datum = wp_parse_args( $field_datum, $default_field_data );
+
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+				<label for="test">Test Name (GRE, GMAT, etc.): </label>
+					<input type="text" id="test" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][test]" value="<?php echo esc_attr( $field_datum['test'] ); ?>" />
+					<label for="required">Required?:  </label>
+
+					<select id="required" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][required]">
+						<option value="None" <?php selected( 'None', $field_datum['required'] ); ?>>Not selected</option>
+						<option value="Optional" <?php selected( 'Optional', $field_datum['required'] ); ?>>Optional</option>
+						<option value="Yes" <?php selected( 'Yes', $field_datum['required'] ); ?>>Yes</option>
+						<option value="No" <?php selected( 'No', $field_datum['required'] ); ?>>No</option>
+					</select>
+					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
+				</span>
+				<?php
+				$field_count++;
+			}
+
+			
+
+			// @codingStandardsIgnoreStart
+			?>
+			<script type="text/template" id="factsheet-requirement-gre-template">
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+				<label for="test">Test Name (GRE, GMAT, etc.): </label>
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][test]" value="" />
+				<label for="required">Required?:  </label>
+
+					<select id="required" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][required]">
+						<option value="None" <?php selected( 'None', $field_datum['required'] ); ?>>Not selected</option>
+						<option value="Optional" <?php selected( 'Optional', $field_datum['required'] ); ?>>Optional</option>
+						<option value="Yes" <?php selected( 'Yes', $field_datum['required'] ); ?>>Yes</option>
+						<option value="No" <?php selected( 'No', $field_datum['required'] ); ?>>No</option>
+					</select>
+					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
+				</span>
+			</script>
+			<input type="button" class="add-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field button" value="Add" />
+			<input type="hidden" name="factsheet_requirement_form_gre_count" id="factsheet_requirement_form_gre_count" value="<?php echo esc_attr( $field_count ); ?>" />
+		</div>
+		<?php
+		// @codingStandardsIgnoreEnd
+	}
+
+	/**
+	 * Outputs the meta field HTML used to capture meta data stored as strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array  $meta
+	 * @param string $key
+	 * @param array  $data
+	 */
+	public static function display_requirements_meta_field( $meta, $key, $data ) {
+		$field_data = maybe_unserialize( $data[ $key ][0] );
+
+		if ( empty( $field_data ) ) {
+			$field_data = array();
+		}
+
+		$default_field_data = array(
+			'score' => '',
+			'test' => '',
+			'description' => '',
+		);
+		$field_count = 0;
+
+		?>
+		<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
+			<span class="factsheet-label"><strong>Language Test Requirements:</strong></span>
+			<?php
+
+			foreach ( $field_data as $field_datum ) {
+				$field_datum = wp_parse_args( $field_datum, $default_field_data );
+
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][score]" value="<?php echo esc_attr( $field_datum['score'] ); ?>" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][test]" value="<?php echo esc_attr( $field_datum['test'] ); ?>" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][description]" value="<?php echo esc_attr( $field_datum['description'] ); ?>" />
+					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
+				</span>
+				<?php
+				$field_count++;
+			}
+
+			// If no fields have been added, provide an empty field by default.
+			if ( 0 === count( $field_data ) ) {
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][score]" value="" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][test]" value="" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][description]" value="" />
+				</span>
+				<?php
+			}
+
+			// @codingStandardsIgnoreStart
+			?>
+			<script type="text/template" id="factsheet-requirement-template">
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][score]" value="" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][test]" value="" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][description]" value="" />
+					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
+				</span>
+			</script>
+			<input type="button" class="add-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field button" value="Add" />
+			<input type="hidden" name="factsheet_requirement_form_count" id="factsheet_requirement_form_count" value="<?php echo esc_attr( $field_count ); ?>" />
+		</div>
+		<?php
+		// @codingStandardsIgnoreEnd
+	}
+	
+	/**
+	 * Outputs the meta field HTML used to capture meta data stored as strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array  $meta
+	 * @param string $key
+	 * @param array  $data
+	 */
+	public static function display_locations_meta_field( $meta, $key, $data ) {
+		$field_data = maybe_unserialize( $data[ $key ][0] );
+
+		if ( empty( $field_data ) ) {
+			$field_data = array();
+		}
+
+		$default_field_data = array(
+			'Pullman' => 'No',
+			'Spokane' => 'No',
+			'Tri-Cities' => 'No',
+			'Vancouver' => 'No',
+			'Everett' => 'No',
+			'Global Campus (online)' => 'No',
+
+		);
+		$field_data = wp_parse_args( $field_data, $default_field_data );
+
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
+			$restricted = true;
+		} else {
+			$restricted = false;
+		}
+
+		?>
+		<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
+			<span class="factsheet-label"><strong>Locations:</strong></span>
+			<?php
+
+			foreach ( $field_data as $location => $location_status ) {
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<label for="location-<?php echo esc_attr( sanitize_key( $location ) ); ?>"><?php echo esc_html( $location ); ?></label>
+					<?php
+					if ( $restricted ) {
+						echo '<span id="location-' . esc_attr( sanitize_key( $location ) ) . '" class="field-value">' . esc_attr( $location_status ) . '</span>';
+					} else {
+						?>
+						<select id="location-<?php echo esc_attr( sanitize_key( $location ) ); ?>"
+							name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $location ); ?>]">
+							<option value="No" <?php selected( 'No', $location_status ); ?>>No</option>
+							<option value="Yes" <?php selected( 'Yes', $location_status ); ?>>Yes</option>
+							<option value="By Exception" <?php selected( 'By Exception', $location_status ); ?>>By Exception</option>
+						</select>
+						<?php
+					}
+					?>
+
+
+				</span>
+				<?php
+			}
+			?>
+		</div>
+		<?php
+	}
+    
+}

--- a/legacy/class-factsheet-redirects.php
+++ b/legacy/class-factsheet-redirects.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Class Factsheet_Redirects
+ *
+ * @package WSUWP_Graduate_School
+ */
+class WSUWP_Factsheet_Redirects  {
+	/**
+	 * Post type slug (e.g. gs-factsheet).
+	 *
+	 * @var string
+	 */
+	private $post_type_slug;
+
+	/**
+	 * Archive URL slug (e.g. degrees).
+	 *
+	 * @var string
+	 */
+	private $archive_slug;
+
+	/**
+	 * @param string $post_type_slug Post type slug.
+	 * @param string $archive_slug   Archive slug for redirects.
+	 */
+	public function __construct( $post_type_slug, $archive_slug ) {
+		$this->post_type_slug = $post_type_slug;
+		$this->archive_slug   = $archive_slug;
+	}
+
+	/**
+	 * Redirects a given degree ID to either the current degree URL or
+	 * to the degrees landing page.
+	 * ...
+	 */
+	public function redirect_factsheet_id( $degree_id ) {
+		$matches = get_posts( array(
+			'post_type' => $this->post_type_slug,
+			'meta_key' => 'gsdp_degree_id',
+			'meta_value' => $degree_id,
+		) );
+
+		if ( 0 !== count( $matches ) ) {
+			$redirect_url = get_permalink( $matches[0]->ID );
+			wp_safe_redirect( $redirect_url, 301 );
+			exit();
+		} else {
+			wp_safe_redirect( home_url( '/' . $this->archive_slug . '/' ), 302 );
+			exit();
+		}
+	}
+
+	/**
+	 * Redirects old factsheet ID URLs to their new URL or to the
+	 * factsheets landing page.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @global WP_Query $wp_query
+	 */
+	public function redirect_old_factsheet_urls() {
+		global $wp_query;
+
+		if ( $wp_query->is_404() && isset( $wp_query->query['post_type'] ) && $this->post_type_slug === $wp_query->query['post_type'] ) {
+			if ( is_numeric( $wp_query->query[ $this->post_type_slug ] ) ) {
+				$degree_id = absint( $wp_query->query[ $this->post_type_slug ] );
+				$this->redirect_factsheet_id( $degree_id );
+			}
+		}
+	}
+
+	/**
+	 * Redirects published factsheets that are set to not be included in the
+	 * program list. If the factsheet is a draft, then it can be previewed by
+	 * those who have access.
+	 *
+	 * @since 0.10.0
+	 */
+	public function redirect_private_factsheets() {
+		if ( ! is_singular( $this->post_type_slug ) ) {
+			return;
+		}
+
+		if ( 'draft' === get_post_status( get_the_ID() ) ) {
+			return;
+		}
+
+		// if ( 1 !== absint( get_post_meta( get_the_ID(), 'gsdp_include_in_programs', true ) ) ) {
+		// 	wp_redirect( home_url( '/' . $this->archive_slug . '/' ) );
+		// 	exit();
+		// }
+	}
+}

--- a/legacy/class-factsheet-sanitizer.php
+++ b/legacy/class-factsheet-sanitizer.php
@@ -1,0 +1,259 @@
+<?php
+/**
+ * Sanitization for factsheet post meta (locations, deadlines, requirements, contacts, GPA).
+ *
+ * Used as sanitize_callback in registered meta and by save flow.
+ *
+ * @package WSUWP_Graduate_School
+ */
+
+class WSUWP_Factsheet_Sanitizer {
+
+	/**
+	 * Sanitizes a GPA value.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param string $gpa The unsanitized GPA.
+	 * @return string The sanitized GPA.
+	 */
+	public static function sanitize_gpa( $gpa ) {
+		$dot_count = substr_count( $gpa, '.' );
+
+		if ( 0 === $dot_count ) {
+			$gpa = absint( $gpa ) . '.0';
+		} elseif ( 1 === $dot_count ) {
+			$parts = explode( '.', $gpa );
+			$gpa   = absint( $parts[0] ) . '.' . absint( $parts[1] );
+		} else {
+			$gpa = '0.0';
+		}
+
+		return $gpa;
+	}
+
+	/**
+	 * Sanitizes a set of locations stored in a string.
+	 *
+	 * @since 0.10.0
+	 *
+	 * @param array $locations Raw locations array.
+	 * @return array Sanitized locations.
+	 */
+	public static function sanitize_locations( $locations ) {
+		if ( ! is_array( $locations ) || 0 === count( $locations ) ) {
+			$locations = array();
+		}
+
+		$location_names = array( 'Pullman', 'Spokane', 'Tri-Cities', 'Vancouver', 'Everett', 'Global Campus (online)' );
+		$clean_locations = array();
+
+		foreach ( $location_names as $location_name ) {
+			if ( ! isset( $locations[ $location_name ] ) || ! in_array( $locations[ $location_name ], array( 'No', 'Yes', 'By Exception' ), true ) ) {
+				$clean_locations[ $location_name ] = 'No';
+			} else {
+				$clean_locations[ $location_name ] = $locations[ $location_name ];
+			}
+		}
+
+		return $clean_locations;
+	}
+
+	/**
+	 * Sanitizes a set of deadlines.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param array $deadlines Raw deadlines array.
+	 * @return array Sanitized deadlines.
+	 */
+	public static function sanitize_deadlines( $deadlines ) {
+		if ( ! is_array( $deadlines ) || 0 === count( $deadlines ) ) {
+			return array();
+		}
+
+		$clean_deadlines = array();
+
+		foreach ( $deadlines as $deadline ) {
+			$clean_deadline = array();
+
+			if ( isset( $deadline['semester'] ) && in_array( $deadline['semester'], array( 'None', 'Fall', 'Spring', 'Summer' ), true ) ) {
+				$clean_deadline['semester'] = $deadline['semester'];
+			} else {
+				$clean_deadline['semester'] = 'None';
+			}
+
+			if ( isset( $deadline['deadline'] ) ) {
+				$clean_deadline['deadline'] = sanitize_text_field( $deadline['deadline'] );
+			} else {
+				$clean_deadline['deadline'] = '';
+			}
+
+			if ( isset( $deadline['international'] ) ) {
+				$clean_deadline['international'] = sanitize_text_field( $deadline['international'] );
+			} else {
+				$clean_deadline['international'] = '';
+			}
+
+			$clean_deadlines[] = $clean_deadline;
+		}
+
+		return $clean_deadlines;
+	}
+
+	/**
+	 * Sanitizes a set of program deadlines.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param array $deadlines_prog Raw program deadlines array.
+	 * @return array Sanitized program deadlines.
+	 */
+	public static function sanitize_deadlines_prog( $deadlines_prog ) {
+		if ( ! is_array( $deadlines_prog ) || 0 === count( $deadlines_prog ) ) {
+			return array();
+		}
+
+		$clean_deadlines_prog = array();
+
+		foreach ( $deadlines_prog as $deadline_prog ) {
+			$clean_deadline_prog = array();
+
+			if ( isset( $deadline_prog['semester'] ) && in_array( $deadline_prog['semester'], array( 'None', 'Fall', 'Spring', 'Summer' ), true ) ) {
+				$clean_deadline_prog['semester'] = $deadline_prog['semester'];
+			} else {
+				$clean_deadline_prog['semester'] = 'None';
+			}
+
+			if ( isset( $deadline_prog['deadline_prog'] ) ) {
+				$clean_deadline_prog['deadline_prog'] = sanitize_text_field( $deadline_prog['deadline_prog'] );
+			} else {
+				$clean_deadline_prog['deadline_prog'] = '';
+			}
+
+			if ( isset( $deadline_prog['international'] ) ) {
+				$clean_deadline_prog['international'] = sanitize_text_field( $deadline_prog['international'] );
+			} else {
+				$clean_deadline_prog['international'] = '';
+			}
+
+			$clean_deadlines_prog[] = $clean_deadline_prog;
+		}
+
+		return $clean_deadlines_prog;
+	}
+
+	/**
+	 * Sanitizes a set of contacts.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param array $contacts Raw contacts array.
+	 * @return array Sanitized contacts.
+	 */
+	public static function sanitize_contacts( $contacts ) {
+		if ( ! is_array( $contacts ) || 0 === count( $contacts ) ) {
+			return array();
+		}
+
+		$clean_contacts = array();
+
+		foreach ( $contacts as $contact ) {
+			$clean_contact = array();
+
+			if ( isset( $contact['name'] ) ) {
+				$clean_contact['name'] = sanitize_text_field( $contact['name'] );
+			} else {
+				$clean_contact['name'] = '';
+			}
+
+			if ( isset( $contact['email'] ) ) {
+				$clean_contact['email'] = sanitize_text_field( $contact['email'] );
+			} else {
+				$clean_contact['email'] = '';
+			}
+
+			$clean_contacts[] = $clean_contact;
+		}
+
+		return $clean_contacts;
+	}
+
+	/**
+	 * Sanitizes GRE requirements.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param array $requirements_gre Raw GRE requirements array.
+	 * @return array Sanitized GRE requirements.
+	 */
+	public static function sanitize_requirements_gre( $requirements_gre ) {
+		if ( ! is_array( $requirements_gre ) || 0 === count( $requirements_gre ) ) {
+			return array();
+		}
+
+		$clean_requirements = array();
+
+		foreach ( $requirements_gre as $requirement ) {
+			$clean_requirement = array();
+
+			if ( isset( $requirement['test'] ) ) {
+				$clean_requirement['test'] = sanitize_text_field( $requirement['test'] );
+			} else {
+				$clean_requirement['test'] = '';
+			}
+
+			if ( isset( $requirement['required'] ) && in_array( $requirement['required'], array( 'None', 'Optional', 'Yes', 'No' ), true ) ) {
+				$clean_requirement['required'] = $requirement['required'];
+			} else {
+				$clean_requirement['required'] = 'None';
+			}
+
+			$clean_requirements[] = $clean_requirement;
+		}
+
+		return $clean_requirements;
+	}
+
+	/**
+	 * Sanitizes language test requirements.
+	 *
+	 * @since 0.4.0
+	 *
+	 * @param array $requirements Raw requirements array.
+	 * @return array Sanitized requirements.
+	 */
+	public static function sanitize_requirements( $requirements ) {
+		if ( ! is_array( $requirements ) || 0 === count( $requirements ) ) {
+			return array();
+		}
+
+		$clean_requirements = array();
+
+		foreach ( $requirements as $requirement ) {
+			$clean_requirement = array();
+
+			if ( isset( $requirement['score'] ) ) {
+				$clean_requirement['score'] = sanitize_text_field( $requirement['score'] );
+			} else {
+				$clean_requirement['score'] = '';
+			}
+
+			if ( isset( $requirement['test'] ) ) {
+				$clean_requirement['test'] = sanitize_text_field( $requirement['test'] );
+			} else {
+				$clean_requirement['test'] = '';
+			}
+
+			if ( isset( $requirement['description'] ) ) {
+				$clean_requirement['description'] = sanitize_text_field( $requirement['description'] );
+			} else {
+				$clean_requirement['description'] = '';
+			}
+
+			$clean_requirements[] = $clean_requirement;
+		}
+
+		return $clean_requirements;
+	}
+}

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -745,22 +745,6 @@ class WSUWP_Graduate_Degree_Programs {
 			<span class="factsheet-label"><strong>Priority Deadlines:</strong></span>
 			<?php
 
-			// If no fields have been added, provide an empty field by default.
-			if ( 0 === count( $field_data ) ) {
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<select name="<?php echo esc_attr( $key ); ?>[0][semester]">
-						<option value="None">Not selected</option>
-						<option value="Fall">Fall</option>
-						<option value="Spring">Spring</option>
-						<option value="Summer">Summer</option>
-					</select>
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][deadline]" value="" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][international]" value="" />
-				</span>
-				<?php
-			}
-
 			foreach ( $field_data as $field_datum ) {
 				$field_datum = wp_parse_args( $field_datum, $default_field_data );
 
@@ -780,7 +764,21 @@ class WSUWP_Graduate_Degree_Programs {
 				$field_count++;
 			}
 
-
+			// If no fields have been added, provide an empty field by default.
+			if ( 0 === count( $field_data ) ) {
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<select name="<?php echo esc_attr( $key ); ?>[0][semester]">
+						<option value="None">Not selected</option>
+						<option value="Fall">Fall</option>
+						<option value="Spring">Spring</option>
+						<option value="Summer">Summer</option>
+					</select>
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][deadline]" value="" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][international]" value="" />
+				</span>
+				<?php
+			}
 
 			// @codingStandardsIgnoreStart
 			?>
@@ -908,25 +906,6 @@ class WSUWP_Graduate_Degree_Programs {
 			<span class="factsheet-label"><strong>Additional Program Requirements:</strong></span>
 			<?php
 
-			// If no fields have been added, provide an empty field by default.
-			if ( 0 === count( $field_data ) ) {
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-				<label for="test">Test Name (GRE, GMAT, etc.): </label>
-
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][test]" value="" />
-					<label for="required">Required?:  </label>
-
-					<select id="required" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][required]">
-						<option value="None" <?php selected( 'None', $default_field_data['required'] ); ?>>Not selected</option>
-						<option value="Optional" <?php selected( 'Optional', $default_field_data['required'] ); ?>>Optional</option>
-						<option value="Yes" <?php selected( 'Yes', $default_field_data['required'] ); ?>>Yes</option>
-						<option value="No" <?php selected( 'No', $default_field_data['required'] ); ?>>No</option>
-					</select>
-				</span>
-				<?php
-			}
-
 			foreach ( $field_data as $field_datum ) {
 				$field_datum = wp_parse_args( $field_datum, $default_field_data );
 
@@ -948,7 +927,24 @@ class WSUWP_Graduate_Degree_Programs {
 				$field_count++;
 			}
 
-			
+			// If no fields have been added, provide an empty field by default.
+			if ( 0 === count( $field_data ) ) {
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+				<label for="test">Test Name (GRE, GMAT, etc.): </label>
+
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][test]" value="" />
+					<label for="required">Required?:  </label>
+
+					<select id="required" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][required]">
+						<option value="None" <?php selected( 'None', $field_datum['required'] ); ?>>Not selected</option>
+						<option value="Optional" <?php selected( 'Optional', $field_datum['required'] ); ?>>Optional</option>
+						<option value="Yes" <?php selected( 'Yes', $field_datum['required'] ); ?>>Yes</option>
+						<option value="No" <?php selected( 'No', $field_datum['required'] ); ?>>No</option>
+					</select>
+				</span>
+				<?php
+			}
 
 			// @codingStandardsIgnoreStart
 			?>

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -745,6 +745,22 @@ class WSUWP_Graduate_Degree_Programs {
 			<span class="factsheet-label"><strong>Priority Deadlines:</strong></span>
 			<?php
 
+			// If no fields have been added, provide an empty field by default.
+			if ( 0 === count( $field_data ) ) {
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+					<select name="<?php echo esc_attr( $key ); ?>[0][semester]">
+						<option value="None">Not selected</option>
+						<option value="Fall">Fall</option>
+						<option value="Spring">Spring</option>
+						<option value="Summer">Summer</option>
+					</select>
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][deadline]" value="" />
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][international]" value="" />
+				</span>
+				<?php
+			}
+
 			foreach ( $field_data as $field_datum ) {
 				$field_datum = wp_parse_args( $field_datum, $default_field_data );
 
@@ -764,21 +780,7 @@ class WSUWP_Graduate_Degree_Programs {
 				$field_count++;
 			}
 
-			// If no fields have been added, provide an empty field by default.
-			if ( 0 === count( $field_data ) ) {
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<select name="<?php echo esc_attr( $key ); ?>[0][semester]">
-						<option value="None">Not selected</option>
-						<option value="Fall">Fall</option>
-						<option value="Spring">Spring</option>
-						<option value="Summer">Summer</option>
-					</select>
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][deadline]" value="" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][international]" value="" />
-				</span>
-				<?php
-			}
+
 
 			// @codingStandardsIgnoreStart
 			?>
@@ -906,6 +908,25 @@ class WSUWP_Graduate_Degree_Programs {
 			<span class="factsheet-label"><strong>Additional Program Requirements:</strong></span>
 			<?php
 
+			// If no fields have been added, provide an empty field by default.
+			if ( 0 === count( $field_data ) ) {
+				?>
+				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
+				<label for="test">Test Name (GRE, GMAT, etc.): </label>
+
+					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][test]" value="" />
+					<label for="required">Required?:  </label>
+
+					<select id="required" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][required]">
+						<option value="None" <?php selected( 'None', $default_field_data['required'] ); ?>>Not selected</option>
+						<option value="Optional" <?php selected( 'Optional', $default_field_data['required'] ); ?>>Optional</option>
+						<option value="Yes" <?php selected( 'Yes', $default_field_data['required'] ); ?>>Yes</option>
+						<option value="No" <?php selected( 'No', $default_field_data['required'] ); ?>>No</option>
+					</select>
+				</span>
+				<?php
+				}
+
 			foreach ( $field_data as $field_datum ) {
 				$field_datum = wp_parse_args( $field_datum, $default_field_data );
 
@@ -927,24 +948,7 @@ class WSUWP_Graduate_Degree_Programs {
 				$field_count++;
 			}
 
-			// If no fields have been added, provide an empty field by default.
-			if ( 0 === count( $field_data ) ) {
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-				<label for="test">Test Name (GRE, GMAT, etc.): </label>
-
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][test]" value="" />
-					<label for="required">Required?:  </label>
-
-					<select id="required" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][required]">
-						<option value="None" <?php selected( 'None', $field_datum['required'] ); ?>>Not selected</option>
-						<option value="Optional" <?php selected( 'Optional', $field_datum['required'] ); ?>>Optional</option>
-						<option value="Yes" <?php selected( 'Yes', $field_datum['required'] ); ?>>Yes</option>
-						<option value="No" <?php selected( 'No', $field_datum['required'] ); ?>>No</option>
-					</select>
-				</span>
-				<?php
-			}
+			
 
 			// @codingStandardsIgnoreStart
 			?>

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -51,7 +51,7 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'Factsheet display name',
 			'type' => 'string',
 			'sanitize_callback' => 'sanitize_text_field',
-			'meta_field_callback' => array( __CLASS__, 'display_string_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_string_meta_field' ),
 			'restricted' => true,
 			'pre_html' => '<div class="factsheet-group">',
 			'location' => 'primary',
@@ -68,14 +68,14 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'Accepting applications',
 			'type' => 'bool',
 			'sanitize_callback' => 'absint',
-			'meta_field_callback' => array( __CLASS__, 'display_bool_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_bool_meta_field' ),
 			'location' => 'primary',
 		),
 		'gsdp_include_in_programs' => array(
 			'description' => 'Include in programs list',
 			'type' => 'bool',
 			'sanitize_callback' => 'absint',
-			'meta_field_callback' => array( __CLASS__, 'display_bool_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_bool_meta_field' ),
 			'restricted' => true,
 			'location' => 'primary',
 		),
@@ -83,14 +83,14 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'Total grad students',
 			'type' => 'int',
 			'sanitize_callback' => 'absint',
-			'meta_field_callback' => array( __CLASS__, 'display_int_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_int_meta_field' ),
 			'location' => 'primary',
 		),
 		'gsdp_grad_faculty_total' => array(
 			'description' => 'Total Graduate Faculty',
 			'type' => 'int',
 			'sanitize_callback' => 'absint',
-			'meta_field_callback' => array( __CLASS__, 'display_int_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_int_meta_field' ),
 			'location' => 'primary',
 		),
 
@@ -98,42 +98,42 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'Total Core Graduate Faculty',
 			'type' => 'int',
 			'sanitize_callback' => 'absint',
-			'meta_field_callback' => array( __CLASS__, 'display_int_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_int_meta_field' ),
 			'location' => 'primary',
 		),
 		'gsdp_grad_students_aided' => array(
 			'description' => 'Aided grad students',
 			'type' => 'int',
 			'sanitize_callback' => 'absint',
-			'meta_field_callback' => array( __CLASS__, 'display_int_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_int_meta_field' ),
 			'location' => 'primary',
 		),
 		'gsdp_program_handbook_url' => array(
 			'description' => 'Program Handbook URL',
 			'type' => 'string',
 			'sanitize_callback' => 'esc_url_raw',
-			'meta_field_callback' => array( __CLASS__, 'display_string_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_string_meta_field' ),
 			'location' => 'primary',
 		),
 		'gsdp_student_learning_outcome_url' => array(
 			'description' => 'Student Learning Outcomes URL',
 			'type' => 'string',
 			'sanitize_callback' => 'esc_url_raw',
-			'meta_field_callback' => array( __CLASS__, 'display_string_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_string_meta_field' ),
 			'location' => 'primary',
 		),
 		'gsdp_application_url' => array(
 			'description' => 'Application URL',
 			'type' => 'string',
 			'sanitize_callback' => 'esc_url_raw',
-			'meta_field_callback' => array( __CLASS__, 'display_string_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_string_meta_field' ),
 			'location' => 'primary',
 		),
 		'gsdp_degree_url' => array(
 			'description' => 'Degree home page',
 			'type' => 'string',
 			'sanitize_callback' => 'esc_url_raw',
-			'meta_field_callback' => array( __CLASS__, 'display_string_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_string_meta_field' ),
 			'post_html' => '</div>',
 			'location' => 'primary',
 		),
@@ -141,7 +141,7 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'Locations',
 			'type' => 'locations',
 			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_locations',
-			'meta_field_callback' => array( __CLASS__, 'display_locations_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_locations_meta_field' ),
 			'restricted' => true,
 			'pre_html' => '<div class="factsheet-group">',
 			
@@ -151,7 +151,7 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'Global Campus URL (if different from physical campus)',
 			'type' => 'string',
 			'sanitize_callback' => 'sanitize_text_field',
-			'meta_field_callback' => array( __CLASS__, 'display_string_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_string_meta_field' ),
 			'restricted' => true,
 			'location' => 'primary',
 			'post_html' => '</div>',
@@ -160,7 +160,7 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'Deadlines',
 			'type' => 'deadlines',
 			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_deadlines',
-			'meta_field_callback' => array( __CLASS__, 'display_deadlines_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_deadlines_meta_field' ),
 			'pre_html' => '<div class="factsheet-group">',
 			'post_html' => '</div>',
 			'location' => 'primary',
@@ -169,7 +169,7 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'Program Deadlines',
 			'type' => 'deadlines_prog',
 			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_deadlines_prog',
-			'meta_field_callback' => array( __CLASS__, 'display_deadlines_prog_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_deadlines_prog_meta_field' ),
 			'pre_html' => '<div class="factsheet-group">',
 			'post_html' => '</div>',
 			'location' => 'primary',
@@ -178,7 +178,7 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'Language Test Requirements',
 			'type' => 'requirements',
 			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_requirements',
-			'meta_field_callback' => array( __CLASS__, 'display_requirements_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_requirements_meta_field' ),
 			'pre_html' => '<div class="factsheet-group">',
 			'post_html' => '</div>',
 			'location' => 'primary',
@@ -187,7 +187,7 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'GRE Requirements',
 			'type' => 'requirements-gre',
 			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_requirements_gre',
-			'meta_field_callback' => array( __CLASS__, 'display_requirements_gre_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_requirements_gre_meta_field' ),
 			'pre_html' => '<div class="factsheet-group">',
 			'post_html' => '</div>',
 			'location' => 'primary',
@@ -196,7 +196,7 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'Contacts',
 			'type' => 'gscontacts',
 			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_contacts',
-			'meta_field_callback' => array( __CLASS__, 'display_contacts_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_contacts_meta_field' ),
 			'pre_html' => '<div class="factsheet-group">',
 			'post_html' => '</div>',
 			'location' => 'primary',
@@ -205,35 +205,35 @@ class WSUWP_Graduate_Degree_Programs {
 			'description' => 'Description of the graduate degree',
 			'type' => 'textarea',
 			'sanitize_callback' => 'wp_kses_post',
-			'meta_field_callback' => array( __CLASS__, 'display_textarea_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_textarea_meta_field' ),
 			'location' => 'secondary',
 		),
 		'gsdp_admission_requirements' => array(
 			'description' => 'Admission requirements',
 			'type' => 'textarea',
 			'sanitize_callback' => 'wp_kses_post',
-			'meta_field_callback' => array( __CLASS__, 'display_textarea_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_textarea_meta_field' ),
 			'location' => 'secondary',
 		),
 		'gsdp_student_opportunities' => array(
 			'description' => 'Student opportunities',
 			'type' => 'textarea',
 			'sanitize_callback' => 'wp_kses_post',
-			'meta_field_callback' => array( __CLASS__, 'display_textarea_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_textarea_meta_field' ),
 			'location' => 'secondary',
 		),
 		'gsdp_career_opportunities' => array(
 			'description' => 'Career opportunities',
 			'type' => 'textarea',
 			'sanitize_callback' => 'wp_kses_post',
-			'meta_field_callback' => array( __CLASS__, 'display_textarea_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_textarea_meta_field' ),
 			'location' => 'secondary',
 		),
 		'gsdp_career_placements' => array(
 			'description' => 'Career placements',
 			'type' => 'textarea',
 			'sanitize_callback' => 'wp_kses_post',
-			'meta_field_callback' => array( __CLASS__, 'display_textarea_meta_field' ),
+			'meta_field_callback' => array( 'WSUWP_Factsheet_Fields_Display', 'display_textarea_meta_field' ),
 			'location' => 'secondary',
 		),
 
@@ -269,6 +269,7 @@ class WSUWP_Graduate_Degree_Programs {
 		require_once dirname( __FILE__ ) . '/class-factsheet-access.php';
 		require_once dirname( __FILE__ ) . '/class-factsheet-admin-assets.php';
 		require_once dirname( __FILE__ ) . '/class-factsheet-sanitizer.php';
+		require_once dirname( __FILE__ ) . '/class-factsheet-fields-display.php';
 		$this->factsheet_redirects = new WSUWP_Factsheet_Redirects( $this->post_type_slug, $this->archive_slug );
 		$this->factsheet_archive = new WSUWP_Factsheet_Archive( $this->post_type_slug );
 		$this->factsheet_admin_assets = new WSUWP_Factsheet_Admin_Assets( $this->post_type_slug );
@@ -459,7 +460,7 @@ class WSUWP_Graduate_Degree_Programs {
 				continue;
 			}
 
-			$this->output_meta_box_html( $meta, $data, $key );
+			WSUWP_Factsheet_Fields_Display::output_meta_box_html( $meta, $data, $key );
 		}
 
 		echo '</div>'; // End factsheet-primary-inputs.
@@ -513,624 +514,12 @@ class WSUWP_Graduate_Degree_Programs {
 				continue;
 			}
 
-			$this->output_meta_box_html( $meta, $data, $key );
+			WSUWP_Factsheet_Fields_Display::output_meta_box_html( $meta, $data, $key );
 		}
 
 		echo '</div>'; // End factsheet-primary-inputs.
 	}
 
-	/**
-	 * Outputs the HTML associated with the primary and secondary meta boxes.
-	 *
-	 * @since 0.7.0
-	 *
-	 * @param $meta
-	 * @param $data
-	 * @param $key
-	 */
-	public function output_meta_box_html( $meta, $data, $key ) {
-		if ( isset( $meta['pre_html'] ) ) {
-			echo $meta['pre_html']; // @codingStandardsIgnoreLine (HTML is static in code)
-		}
-		?>
-		<div class="factsheet-primary-input factsheet-<?php echo esc_attr( $meta['type'] ); ?>">
-		<?php
-
-		if ( isset( $meta['meta_field_callback'] ) && is_callable( $meta['meta_field_callback'] ) ) {
-			call_user_func( $meta['meta_field_callback'], $meta, $key, $data );
-		}
-
-		echo '</div>'; // End factsheet-primary-input
-
-		if ( isset( $meta['post_html'] ) ) {
-			echo $meta['post_html']; // @codingStandardsIgnoreLine (HTML is static in code)
-		}
-	}
-
-	/**
-	 * Outputs the meta field HTML used to capture meta data stored as strings.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param array  $meta
-	 * @param string $key
-	 * @param array  $data
-	 */
-	public function display_string_meta_field( $meta, $key, $data ) {
-		?>
-		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
-		<?php
-
-		// Check if field is restricted and user is a restricted contributor
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
-			$disabled = 'disabled';
-		} else {
-			$disabled = '';
-		}
-
-		?>
-		<input type="text" name="<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $data[ $key ][0] ); ?>" <?php echo $disabled; // @codingStandardsIgnoreLine (HTML is static in code) ?> />
-		<?php
-	}
-
-	/**
-	 * Outputs the meta field HTML used to capture meta data stored as an integer.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param array  $meta
-	 * @param string $key
-	 * @param array  $data
-	 */
-	public function display_int_meta_field( $meta, $key, $data ) {
-		?>
-		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
-		<?php
-
-		// Check if field is restricted and user is a restricted contributor
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
-			$disabled = 'disabled';
-		} else {
-			$disabled = '';
-		}
-
-		?>
-		<input type="text" id="<?php echo esc_attr( $key ); ?>" name="<?php echo esc_attr( $key ); ?>" value="<?php echo absint( $data[ $key ][0] ); ?>" <?php echo $disabled; // @codingStandardsIgnoreLine (HTML is static in code) ?> />
-		<?php
-	}
-
-	/**
-	 * Outputs the meta field HTML used to capture meta data stored as boolean.
-	 *
-	 * @since 1.3.0
-	 * @since 1.4.0 Added support for restricted fields that are disabled for contributors.
-	 *
-	 * @param array  $meta
-	 * @param string $key
-	 * @param array  $data
-	 */
-	public function display_bool_meta_field( $meta, $key, $data ) {
-		// Check if field is restricted and user is a restricted contributor
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
-			$disabled = 'disabled';
-		} else {
-			$disabled = '';
-		}
-
-		?>
-		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
-		<select name="<?php echo esc_attr( $key ); ?>" <?php echo $disabled; // @codingStandardsIgnoreLine ?>>
-			<option value="0" <?php selected( 0, absint( $data[ $key ][0] ) ); ?>>No</option>
-			<option value="1" <?php selected( 1, absint( $data[ $key ][0] ) ); ?>>Yes</option>
-		</select>
-		<?php
-	}
-
-	/**
-	 * Outputs the meta field HTML used to capture meta data stored as strings.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param array  $meta
-	 * @param string $key
-	 * @param array  $data
-	 */
-	public function display_textarea_meta_field( $meta, $key, $data ) {
-		?>
-		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
-		<?php
-
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
-			echo '<div id="' . esc_attr( $key ) . '" class="field-content">' . wp_kses_post( apply_filters( 'the_content', $data[ $key ][0] ) ) . '</div>';
-			return;
-		}
-
-		$wp_editor_settings = array(
-			'textarea_rows' => 10,
-			'media_buttons' => false,
-			'teeny' => true,
-		);
-
-		wp_editor( $data[ $key ][0], esc_attr( $key ), $wp_editor_settings );
-	}
-
-		/**
-	 * Outputs the meta field HTML used to capture meta data stored as strings.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param array  $meta
-	 * @param string $key
-	 * @param array  $data
-	 */
-	public function display_deadlines_prog_meta_field( $meta, $key, $data ) {
-		$field_data = maybe_unserialize( $data[ $key ][0] );
-
-		if ( empty( $field_data ) ) {
-			$field_data = array();
-		}
-
-		$default_field_data = array(
-			'semester' => 'None',
-			'deadline' => '',
-			'international' => '',
-		);
-		$field_count = 0;
-
-		?>
-		<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
-			<span class="factsheet-label"><strong>Program Deadlines:</strong></span>
-			<?php
-
-			foreach ( $field_data as $field_datum ) {
-				$field_datum = wp_parse_args( $field_datum, $default_field_data );
-
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<select name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][semester]">
-						<option value="None" <?php selected( 'None', $field_datum['semester'] ); ?>>Not selected</option>
-						<option value="Fall" <?php selected( 'Fall', $field_datum['semester'] ); ?>>Fall</option>
-						<option value="Spring" <?php selected( 'Spring', $field_datum['semester'] ); ?>>Spring</option>
-						<option value="Summer" <?php selected( 'Summer', $field_datum['semester'] ); ?>>Summer</option>
-					</select>
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][deadline]" value="<?php echo esc_attr( $field_datum['deadline'] ); ?>" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][international]" value="<?php echo esc_attr( $field_datum['international'] ); ?>" />
-					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
-				</span>
-				<?php
-				$field_count++;
-			}
-
-			// If no fields have been added, provide an empty field by default.
-			if ( 0 === count( $field_data ) ) {
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<select name="<?php echo esc_attr( $key ); ?>[0][semester]">
-						<option value="None">Not selected</option>
-						<option value="Fall">Fall</option>
-						<option value="Spring">Spring</option>
-						<option value="Summer">Summer</option>
-					</select>
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][deadline]" value="" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][international]" value="" />
-				</span>
-				<?php
-			}
-
-			// @codingStandardsIgnoreStart
-			?>
-			<script type="text/template" id="factsheet-deadlines_prog-template">
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<select name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][semester]">
-						<option value="None">Not selected</option>
-						<option value="Fall">Fall</option>
-						<option value="Spring">Spring</option>
-						<option value="Summer">Summer</option>
-					</select>
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][deadline]" value="" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][international]" value="" />
-					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
-				</span>
-			</script>
-			<input type="button" class="add-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field button" value="Add" />
-			<input type="hidden" name="factsheet_deadlines_prog_form_count" id="factsheet_deadlines_prog_form_count" value="<?php echo esc_attr( $field_count ); ?>" />
-		</div>
-		<?php
-		// @codingStandardsIgnoreEnd
-	}
-
-	/**
-	 * Outputs the meta field HTML used to capture meta data stored as strings.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param array  $meta
-	 * @param string $key
-	 * @param array  $data
-	 */
-	public function display_deadlines_meta_field( $meta, $key, $data ) {
-		$field_data = maybe_unserialize( $data[ $key ][0] );
-
-		if ( empty( $field_data ) ) {
-			$field_data = array();
-		}
-
-		$default_field_data = array(
-			'semester' => 'None',
-			'deadline' => '',
-			'international' => '',
-		);
-		$field_count = 0;
-
-		?>
-		<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
-			<span class="factsheet-label"><strong>Priority Deadlines:</strong></span>
-			<?php
-
-			// If no fields have been added, provide an empty field by default.
-			if ( 0 === count( $field_data ) ) {
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<select name="<?php echo esc_attr( $key ); ?>[0][semester]">
-						<option value="None">Not selected</option>
-						<option value="Fall">Fall</option>
-						<option value="Spring">Spring</option>
-						<option value="Summer">Summer</option>
-					</select>
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][deadline]" value="" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][international]" value="" />
-				</span>
-				<?php
-			}
-
-			foreach ( $field_data as $field_datum ) {
-				$field_datum = wp_parse_args( $field_datum, $default_field_data );
-
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<select name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][semester]">
-						<option value="None" <?php selected( 'None', $field_datum['semester'] ); ?>>Not selected</option>
-						<option value="Fall" <?php selected( 'Fall', $field_datum['semester'] ); ?>>Fall</option>
-						<option value="Spring" <?php selected( 'Spring', $field_datum['semester'] ); ?>>Spring</option>
-						<option value="Summer" <?php selected( 'Summer', $field_datum['semester'] ); ?>>Summer</option>
-					</select>
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][deadline]" value="<?php echo esc_attr( $field_datum['deadline'] ); ?>" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][international]" value="<?php echo esc_attr( $field_datum['international'] ); ?>" />
-					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
-				</span>
-				<?php
-				$field_count++;
-			}
-
-
-
-			// @codingStandardsIgnoreStart
-			?>
-			<script type="text/template" id="factsheet-deadline-template">
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<select name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][semester]">
-						<option value="None">Not selected</option>
-						<option value="Fall">Fall</option>
-						<option value="Spring">Spring</option>
-						<option value="Summer">Summer</option>
-					</select>
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][deadline]" value="" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][international]" value="" />
-					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
-				</span>
-			</script>
-			<input type="button" class="add-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field button" value="Add" />
-			<input type="hidden" name="factsheet_deadline_form_count" id="factsheet_deadline_form_count" value="<?php echo esc_attr( $field_count ); ?>" />
-		</div>
-		<?php
-		// @codingStandardsIgnoreEnd
-	}
-
-
-		/**
-	 * Outputs the meta field HTML used to capture meta data stored as strings.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param array  $meta
-	 * @param string $key
-	 * @param array  $data
-	 */
-	public function display_contacts_meta_field( $meta, $key, $data ) {
-			$field_data = maybe_unserialize( $data[ $key ][0] );
-	
-			if ( empty( $field_data ) ) {
-				$field_data = array();
-			}
-	
-			$default_field_data = array(
-				'name' => '',
-				'email' => '',
-			);
-			$field_count = 0;
-	
-			?>
-			<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
-				<span class="factsheet-label"><strong>Contact Information: </strong></span>
-				<?php
-	
-				foreach ( $field_data as $field_datum ) {
-					$field_datum = wp_parse_args( $field_datum, $default_field_data );
-	
-					?>
-					<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-						<label for="Name">Name: </label>
-						<input type="text" id="Name" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][name]" value="<?php echo esc_attr( $field_datum['name'] ); ?>" />
-						<label for="Email">Email: </label>
-						<input type="text" id ="Email" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][email]" value="<?php echo esc_attr( $field_datum['email'] ); ?>" />
-						<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
-					</span>
-					<?php
-					$field_count++;
-				}
-	
-				// If no fields have been added, provide an empty field by default.
-				if ( 0 === count( $field_data ) ) {
-					?>
-					<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<label for="Name">Name: </label>
-	
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][name]" value="" /><br>
-					<label for="Email">Email: </label>
-
-						<input type="text" name="<?php echo esc_attr( $key ); ?>[0][email]" value="" />
-					</span>
-					<?php
-				}
-	
-				// @codingStandardsIgnoreStart
-				?>
-				<script type="text/template" id="factsheet-gscontacts-template">
-					<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<label for="Name">Name: </label>
-						<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][name]" value="" />
-						<label for="Email">Email: </label>
-						<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][email]" value="" />
-						<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
-					</span>
-				</script>
-				<input type="button" class="add-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field button" value="Add" />
-				<input type="hidden" name="factsheet_gscontacts_count" id="factsheet_gscontacts_count" value="<?php echo esc_attr( $field_count ); ?>" />
-			</div>
-			<?php
-			// @codingStandardsIgnoreEnd
-		}
-	
-
-
-	/**
-	 * Outputs the meta field HTML used to capture meta data stored as strings.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param array  $meta
-	 * @param string $key
-	 * @param array  $data
-	 */
-	public function display_requirements_gre_meta_field( $meta, $key, $data ) {
-		$field_data = maybe_unserialize( $data[ $key ][0] );
-
-		if ( empty( $field_data ) ) {
-			$field_data = array();
-		}
-
-		$default_field_data = array(
-			'required' => 'None',
-			'test' => '',
-		);
-		$field_count = 0;
-
-		?>
-		<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
-			<span class="factsheet-label"><strong>Additional Program Requirements:</strong></span>
-			<?php
-
-			// If no fields have been added, provide an empty field by default.
-			if ( 0 === count( $field_data ) ) {
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-				<label for="test">Test Name (GRE, GMAT, etc.): </label>
-
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][test]" value="" />
-					<label for="required">Required?:  </label>
-
-					<select id="required" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][required]">
-						<option value="None" <?php selected( 'None', $default_field_data['required'] ); ?>>Not selected</option>
-						<option value="Optional" <?php selected( 'Optional', $default_field_data['required'] ); ?>>Optional</option>
-						<option value="Yes" <?php selected( 'Yes', $default_field_data['required'] ); ?>>Yes</option>
-						<option value="No" <?php selected( 'No', $default_field_data['required'] ); ?>>No</option>
-					</select>
-				</span>
-				<?php
-				}
-
-			foreach ( $field_data as $field_datum ) {
-				$field_datum = wp_parse_args( $field_datum, $default_field_data );
-
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-				<label for="test">Test Name (GRE, GMAT, etc.): </label>
-					<input type="text" id="test" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][test]" value="<?php echo esc_attr( $field_datum['test'] ); ?>" />
-					<label for="required">Required?:  </label>
-
-					<select id="required" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][required]">
-						<option value="None" <?php selected( 'None', $field_datum['required'] ); ?>>Not selected</option>
-						<option value="Optional" <?php selected( 'Optional', $field_datum['required'] ); ?>>Optional</option>
-						<option value="Yes" <?php selected( 'Yes', $field_datum['required'] ); ?>>Yes</option>
-						<option value="No" <?php selected( 'No', $field_datum['required'] ); ?>>No</option>
-					</select>
-					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
-				</span>
-				<?php
-				$field_count++;
-			}
-
-			
-
-			// @codingStandardsIgnoreStart
-			?>
-			<script type="text/template" id="factsheet-requirement-gre-template">
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-				<label for="test">Test Name (GRE, GMAT, etc.): </label>
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][test]" value="" />
-				<label for="required">Required?:  </label>
-
-					<select id="required" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][required]">
-						<option value="None" <?php selected( 'None', $field_datum['required'] ); ?>>Not selected</option>
-						<option value="Optional" <?php selected( 'Optional', $field_datum['required'] ); ?>>Optional</option>
-						<option value="Yes" <?php selected( 'Yes', $field_datum['required'] ); ?>>Yes</option>
-						<option value="No" <?php selected( 'No', $field_datum['required'] ); ?>>No</option>
-					</select>
-					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
-				</span>
-			</script>
-			<input type="button" class="add-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field button" value="Add" />
-			<input type="hidden" name="factsheet_requirement_form_gre_count" id="factsheet_requirement_form_gre_count" value="<?php echo esc_attr( $field_count ); ?>" />
-		</div>
-		<?php
-		// @codingStandardsIgnoreEnd
-	}
-
-	/**
-	 * Outputs the meta field HTML used to capture meta data stored as strings.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param array  $meta
-	 * @param string $key
-	 * @param array  $data
-	 */
-	public function display_requirements_meta_field( $meta, $key, $data ) {
-		$field_data = maybe_unserialize( $data[ $key ][0] );
-
-		if ( empty( $field_data ) ) {
-			$field_data = array();
-		}
-
-		$default_field_data = array(
-			'score' => '',
-			'test' => '',
-			'description' => '',
-		);
-		$field_count = 0;
-
-		?>
-		<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
-			<span class="factsheet-label"><strong>Language Test Requirements:</strong></span>
-			<?php
-
-			foreach ( $field_data as $field_datum ) {
-				$field_datum = wp_parse_args( $field_datum, $default_field_data );
-
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][score]" value="<?php echo esc_attr( $field_datum['score'] ); ?>" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][test]" value="<?php echo esc_attr( $field_datum['test'] ); ?>" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $field_count ); ?>][description]" value="<?php echo esc_attr( $field_datum['description'] ); ?>" />
-					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
-				</span>
-				<?php
-				$field_count++;
-			}
-
-			// If no fields have been added, provide an empty field by default.
-			if ( 0 === count( $field_data ) ) {
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][score]" value="" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][test]" value="" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[0][description]" value="" />
-				</span>
-				<?php
-			}
-
-			// @codingStandardsIgnoreStart
-			?>
-			<script type="text/template" id="factsheet-requirement-template">
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][score]" value="" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][test]" value="" />
-					<input type="text" name="<?php echo esc_attr( $key ); ?>[<%= form_count %>][description]" value="" />
-					<span class="remove-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">Remove</span>
-				</span>
-			</script>
-			<input type="button" class="add-factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field button" value="Add" />
-			<input type="hidden" name="factsheet_requirement_form_count" id="factsheet_requirement_form_count" value="<?php echo esc_attr( $field_count ); ?>" />
-		</div>
-		<?php
-		// @codingStandardsIgnoreEnd
-	}
-	
-	/**
-	 * Outputs the meta field HTML used to capture meta data stored as strings.
-	 *
-	 * @since 1.3.0
-	 *
-	 * @param array  $meta
-	 * @param string $key
-	 * @param array  $data
-	 */
-	public function display_locations_meta_field( $meta, $key, $data ) {
-		$field_data = maybe_unserialize( $data[ $key ][0] );
-
-		if ( empty( $field_data ) ) {
-			$field_data = array();
-		}
-
-		$default_field_data = array(
-			'Pullman' => 'No',
-			'Spokane' => 'No',
-			'Tri-Cities' => 'No',
-			'Vancouver' => 'No',
-			'Everett' => 'No',
-			'Global Campus (online)' => 'No',
-
-		);
-		$field_data = wp_parse_args( $field_data, $default_field_data );
-
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
-			$restricted = true;
-		} else {
-			$restricted = false;
-		}
-
-		?>
-		<div class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-wrapper">
-			<span class="factsheet-label"><strong>Locations:</strong></span>
-			<?php
-
-			foreach ( $field_data as $location => $location_status ) {
-				?>
-				<span class="factsheet-<?php echo esc_attr( $meta['type'] ); ?>-field">
-					<label for="location-<?php echo esc_attr( sanitize_key( $location ) ); ?>"><?php echo esc_html( $location ); ?></label>
-					<?php
-					if ( $restricted ) {
-						echo '<span id="location-' . esc_attr( sanitize_key( $location ) ) . '" class="field-value">' . esc_attr( $location_status ) . '</span>';
-					} else {
-						?>
-						<select id="location-<?php echo esc_attr( sanitize_key( $location ) ); ?>"
-							name="<?php echo esc_attr( $key ); ?>[<?php echo esc_attr( $location ); ?>]">
-							<option value="No" <?php selected( 'No', $location_status ); ?>>No</option>
-							<option value="Yes" <?php selected( 'Yes', $location_status ); ?>>Yes</option>
-							<option value="By Exception" <?php selected( 'By Exception', $location_status ); ?>>By Exception</option>
-						</select>
-						<?php
-					}
-					?>
-
-
-				</span>
-				<?php
-			}
-			?>
-		</div>
-		<?php
-	}
 
 	/**
 	 * Prevents restricted contributors from editing a factsheet's title.

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -17,6 +17,11 @@ class WSUWP_Graduate_Degree_Programs {
 	private static $instance;
 
 	/**
+	 * @var WSUWP_Factsheet_Admin_Assets
+	 */
+	private $factsheet_admin_assets;
+
+	/**
 	 * The slug used to register the factsheet post type.
 	 *
 	 * @since 0.4.0
@@ -262,11 +267,14 @@ class WSUWP_Graduate_Degree_Programs {
 		require_once dirname( __FILE__ ) . '/class-factsheet-archive.php';
 		require_once dirname( __FILE__ ) . '/class-factsheet-data.php';
 		require_once dirname( __FILE__ ) . '/class-factsheet-access.php';
+		require_once dirname( __FILE__ ) . '/class-factsheet-admin-assets.php';
 		$this->factsheet_redirects = new WSUWP_Factsheet_Redirects( $this->post_type_slug, $this->archive_slug );
 		$this->factsheet_archive = new WSUWP_Factsheet_Archive( $this->post_type_slug );
+		$this->factsheet_admin_assets = new WSUWP_Factsheet_Admin_Assets( $this->post_type_slug );
+
 
 		add_filter( 'admin_body_class', array( $this, 'add_factsheet_admin_body_classes' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( $this->factsheet_admin_assets, 'admin_enqueue_scripts' ) );
 
 		add_action( 'init', array( $this, 'register_post_type' ), 15 );
 		add_action( 'init', 'WSUWP_Graduate_Degree_Program_Name_Taxonomy', 15 );
@@ -298,32 +306,6 @@ class WSUWP_Graduate_Degree_Programs {
 		add_filter( 'spine_get_title', array( $this->factsheet_archive, 'filter_factsheet_archive_title' ), 10, 3 );
 	}
 
-	/**
-	 * Enqueue scripts and styles used in the admin.
-	 *
-	 * @since 0.4.0
-	 * @since 1.4.0 Added inline styles to disable title/permalink for restricted contributors.
-	 *
-	 * @param string $hook_suffix
-	 */
-	public function admin_enqueue_scripts( $hook_suffix ) {
-		if ( in_array( $hook_suffix, array( 'post.php', 'post-new.php' ), true ) && 'gs-factsheet' === get_current_screen()->id ) {
-			wp_deregister_script( 'yoast-seo-post-scraper' );
-			wp_deregister_script( 'yoast-seo-term-scraper' );
-			wp_deregister_script( 'yoast-seo-featured-image' );
-
-			wp_enqueue_style( 'gsdp-admin', WSUWP\Plugin\Graduate\Plugin::get('url'). '/css/factsheet-admin.css', array(), WSUWP_Graduate_School_Theme()->theme_version() );
-			wp_register_script( 'gsdp-factsheet-admin', WSUWP\Plugin\Graduate\Plugin::get('url'). '/js/factsheet-admin.min.js', array( 'jquery', 'underscore', 'jquery-ui-autocomplete' ), WSUWP_Graduate_School_Theme()->theme_version(), true );
-
-			wp_enqueue_script( 'gsdp-factsheet-admin' );
-
-		}
-		
-
-		if ( in_array( $hook_suffix, array( 'edit-tags.php', 'term.php', 'term-new.php' ), true ) && in_array( get_current_screen()->taxonomy, array( 'gs-degree-type' ), true ) ) {
-			wp_enqueue_style( 'gsdp-faculty-admin', WSUWP\Plugin\Graduate\Plugin::get('url'). '/css/faculty-admin.css', array(), WSUWP_Graduate_School_Theme()->theme_version() );
-		}
-	}
 	/**
 	 * Add body classes on factsheet edit screen for conditional admin CSS/JS.
 	 *
@@ -434,7 +416,7 @@ class WSUWP_Graduate_Degree_Programs {
 	 * Removes unnecessary meta boxes from the factsheet screen.
 	 *
 	 * Note: Program Names and Degree Types taxonomy boxes are NOT removed here.
-	 * They are greyed out (disabled) via CSS/JS in admin_enqueue_scripts() for
+	 * They are greyed out (disabled) via CSS/JS in Factsheet_Admin_Assets::admin_enqueue_scripts() for
 	 * restricted contributors.
 	 *
 	 * @since 0.7.0

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -389,6 +389,32 @@ class WSUWP_Graduate_Degree_Programs {
 				';
 				wp_add_inline_script( 'gsdp-factsheet-admin', $custom_js );
 			}
+			// Disable Editorial Access Manager (Factsheet Team) panel for non-admins
+			if ( ! current_user_can( 'manage_options' ) ) {
+				$eam_css = '
+					/* Disable EAM / Factsheet Team panel (greyed out) for non-admins */
+					#gsdp-team-members {
+						pointer-events: none;
+						opacity: 0.5;
+					}
+					#gsdp-team-members .inside {
+						background-color: #f0f0f0;
+					}
+					#gsdp-team-members input,
+					#gsdp-team-members select,
+					#gsdp-team-members button {
+						cursor: not-allowed;
+					}
+				';
+				wp_add_inline_style( 'gsdp-admin', $eam_css );
+
+				$eam_js = '
+					jQuery(document).ready(function($) {
+						$("#gsdp-team-members input, #gsdp-team-members select, #gsdp-team-members button").prop("disabled", true);
+					});
+				';
+				wp_add_inline_script( 'gsdp-factsheet-admin', $eam_js );
+			}
 		}
 
 		if ( in_array( $hook_suffix, array( 'edit-tags.php', 'term.php', 'term-new.php' ), true ) && in_array( get_current_screen()->taxonomy, array( 'gs-degree-type' ), true ) ) {

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -260,6 +260,7 @@ class WSUWP_Graduate_Degree_Programs {
 		require_once dirname( __FILE__ ) . '/class-graduate-degree-degree-type-taxonomy.php';
 		require_once dirname( __FILE__ ) . '/class-factsheet-redirects.php';
 		require_once dirname( __FILE__ ) . '/class-factsheet-archive.php';
+		require_once dirname( __FILE__ ) . '/class-factsheet-data.php';
 		$this->factsheet_redirects = new WSUWP_Factsheet_Redirects( $this->post_type_slug, $this->archive_slug );
 		$this->factsheet_archive = new WSUWP_Factsheet_Archive( $this->post_type_slug );
 
@@ -1662,7 +1663,6 @@ class WSUWP_Graduate_Degree_Programs {
 		// end last modified update.
 	}
 
-
 	/**
 	 * Returns a usable subset of data for displaying a factsheet.
 	 *
@@ -1673,172 +1673,7 @@ class WSUWP_Graduate_Degree_Programs {
 	 * @return array
 	 */
 	public static function get_factsheet_data( $post_id ) {
-		$factsheet_data = get_registered_metadata( 'post', $post_id );
-
-		$data = array(
-			'degree_id' => 0,
-			'shortname' => '',
-			'description' => '',
-			'accepting_applications' => 'No',
-			'faculty' => array(),
-			'students' => 0,
-			'aided' => 0,
-			'totalfac' => 0,
-			'totalcorefac' => 0,
-			'degree_url' => 'Not available',
-			'student_learning_outcome_url' =>'', 
-			'application_url' => 'https://gradschool.wsu.edu/apply/',
-			'handbook_url' => '',
-			'deadlines' => array(),
-			'deadlines_prog' => array(),
-			'requirements' => array(),
-			'requirements_gre' => array(),
-			'contacts' => array(),
-			'locations' => array(
-				'Pullman' => 'No',
-				'Spokane' => 'No',
-				'Tri-Cities' => 'No',
-				'Vancouver' => 'No',
-				'Everett' => 'No',
-				'Global Campus (online)' => 'No',
-			),
-			'global_URL' => '',
-			'admission_requirements',
-			'student_opportunities',
-			'career_opportunities',
-			'career_placements',
-			'student_learning_outcome',
-			'public' => 'No',
-		);
-
-		if ( isset( $factsheet_data['gsdp_degree_description'][0] ) ) {
-			$data['description'] = $factsheet_data['gsdp_degree_description'][0];
-		}
-
-		// if ( isset( $factsheet_data['gsdp_degree_id'][0] ) ) {
-		// 	$data['degree_id'] = $factsheet_data['gsdp_degree_id'][0];
-		// }
-
-		if ( isset( $factsheet_data['gsdp_include_in_programs'][0] ) && 1 === absint( $factsheet_data['gsdp_include_in_programs'][0] ) ) {
-			$data['public'] = 'Yes';
-		}
-
-		if ( isset( $factsheet_data['gsdp_degree_shortname'][0] ) ) {
-			$data['shortname'] = $factsheet_data['gsdp_degree_shortname'][0];
-		}
-
-		if ( isset( $factsheet_data['gsdp_accepting_applications'][0] ) && 1 === absint( $factsheet_data['gsdp_accepting_applications'][0] ) ) {
-			$data['accepting_applications'] = 'Yes';
-		}
-
-		if ( isset( $factsheet_data['gsdp_grad_students_total'][0] ) ) {
-			$data['students'] = $factsheet_data['gsdp_grad_students_total'][0];
-		}
-
-		if ( isset( $factsheet_data['gsdp_grad_faculty_total'][0] ) ) {
-			$data['totalfac'] = $factsheet_data['gsdp_grad_faculty_total'][0];
-		}
-
-		if ( isset( $factsheet_data['gsdp_grad_core_faculty_total'][0] ) ) {
-			$data['totalcorefac'] = $factsheet_data['gsdp_grad_core_faculty_total'][0];
-		}
-
-		if ( isset( $factsheet_data['gsdp_grad_students_total'][0] ) ) {
-			$data['students'] = $factsheet_data['gsdp_grad_students_total'][0];
-		}
-
-		if ( isset( $factsheet_data['gsdp_grad_students_aided'][0] ) ) {
-			if ( 0 === absint( $data['students'] ) ) {
-				$data['aided'] = '0.00';
-			} else {
-				$data['aided'] = $factsheet_data['gsdp_grad_students_aided'][0];
-			}
-		}
-
-		if ( isset( $factsheet_data['gsdp_degree_url'][0] ) ) {
-			$data['degree_url'] = $factsheet_data['gsdp_degree_url'][0];
-		}
-
-		if ( isset( $factsheet_data['gsdp_application_url'][0] ) ) {
-			$data['application_url'] = $factsheet_data['gsdp_application_url'][0];
-		}
-		
-
-		if ( isset( $factsheet_data['gsdp_student_learning_outcome_url'][0] ) ) {
-			$data['student_learning_outcome_url'] = $factsheet_data['gsdp_student_learning_outcome_url'][0];
-		}
-
-
-		if ( isset( $factsheet_data['gsdp_program_handbook_url'][0] ) ) {
-			$data['handbook_url'] = $factsheet_data['gsdp_program_handbook_url'][0];
-		}
-
-		if ( isset( $factsheet_data['gsdp_deadlines'][0] ) ) {
-			$data['deadlines'] = maybe_unserialize( $factsheet_data['gsdp_deadlines'][0] );
-
-			if ( ! is_array( $data['deadlines'] ) ) {
-				$data['deadlines'] = array();
-			}
-		}
-
-		if ( isset( $factsheet_data['gsdp_deadlines_prog'][0] ) ) {
-			$data['deadlines_prog'] = maybe_unserialize( $factsheet_data['gsdp_deadlines_prog'][0] );
-
-			if ( ! is_array( $data['deadlines_prog'] ) ) {
-				$data['deadlines_prog'] = array();
-			}
-		}
-
-		if ( isset( $factsheet_data['gsdp_requirements_gre'][0] ) ) {
-			$data['requirements_gre'] = maybe_unserialize( $factsheet_data['gsdp_requirements_gre'][0] );
-
-			if ( ! is_array( $data['requirements_gre'] ) ) {
-				$data['requirements_gre'] = array();
-			}
-		}
-
-		if ( isset( $factsheet_data['gsdp_requirements'][0] ) ) {
-			$data['requirements'] = maybe_unserialize( $factsheet_data['gsdp_requirements'][0] );
-
-			if ( ! is_array( $data['requirements'] ) ) {
-				$data['requirements'] = array();
-			}
-		}
-
-		if ( isset( $factsheet_data['gsdp_contacts'][0] ) ) {
-			$data['gscontacts'] = maybe_unserialize( $factsheet_data['gsdp_contacts'][0] );
-
-			if ( ! is_array( $data['gscontacts'] ) ) {
-				$data['gscontacts'] = array();
-			}
-		}
-
-		if ( isset( $factsheet_data['gsdp_locations'][0] ) ) {
-			$locations = maybe_unserialize( $factsheet_data['gsdp_locations'][0] );
-			$data['locations'] = wp_parse_args( $locations, $data['locations'] );
-		}
-
-		if ( isset( $factsheet_data['gsdp_admission_requirements'][0] ) ) {
-			$data['admission_requirements'] = $factsheet_data['gsdp_admission_requirements'][0];
-		}
-
-		if ( isset( $factsheet_data['gsdp_student_opportunities'][0] ) ) {
-			$data['student_opportunities'] = $factsheet_data['gsdp_student_opportunities'][0];
-		}
-
-		if ( isset( $factsheet_data['gsdp_career_opportunities'][0] ) ) {
-			$data['career_opportunities'] = $factsheet_data['gsdp_career_opportunities'][0];
-		}
-
-		if ( isset( $factsheet_data['gsdp_career_placements'][0] ) ) {
-			$data['career_placements'] = $factsheet_data['gsdp_career_placements'][0];
-		}
-
-		if ( isset( $factsheet_data['gsdp_global_URL'][0] ) ) {
-			$data['global_URL'] = $factsheet_data['gsdp_global_URL'][0];
-		}
-
-		return $data;
+		return WSUWP_Factsheet_Data::get_factsheet_data( $post_id );
 	}
 
 	/**

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -1662,19 +1662,6 @@ class WSUWP_Graduate_Degree_Programs {
 		// end last modified update.
 	}
 
-	/**
-	 * Deprecated. Capability mapping is now handled by
-	 * {@see \WSUWP\Plugin\Graduate\Factsheet_Team::map_meta_cap()}.
-	 *
-	 * Kept for reference; the filter hook has been removed from setup_hooks().
-	 *
-	 * @since 1.1.0
-	 * @deprecated 1.3.0
-	 */
-	public function filter_map_meta_cap( $caps, $cap, $user_id, $args ) {
-		return $caps;
-	}
-
 
 	/**
 	 * Returns a usable subset of data for displaying a factsheet.

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -276,9 +276,6 @@ class WSUWP_Graduate_Degree_Programs {
 		add_filter( "auth_post_meta_gsdp_include_in_programs_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
 		add_filter( 'wp_insert_post_data', array( $this, 'manage_factsheet_title_update' ), 10, 2 );
 
-		// Block taxonomy term assignment for restricted contributors.
-		add_action( 'set_object_terms', array( $this, 'maybe_restore_taxonomy_terms' ), 10, 6 );
-
 		add_action( 'pre_get_posts', array( $this, 'adjust_factsheet_archive_query' ) );
 		add_action( 'template_redirect', array( $this, 'redirect_old_factsheet_urls' ) );
 		add_action( 'template_redirect', array( $this, 'redirect_private_factsheets' ) );
@@ -1218,8 +1215,6 @@ class WSUWP_Graduate_Degree_Programs {
 
 		if ( 'users' === $enable_custom_access ) {
 			$allowed_users = (array) get_post_meta( $post_id, 'eam_allowed_users', true );
-			//log allowed users
-			error_log( print_r( $allowed_users, true ) );
 
 			if ( in_array( $user_id, $allowed_users ) ) { // @codingStandardsIgnoreLine (Converting user IDs to ints is not worth it)
 				return true;
@@ -1323,77 +1318,15 @@ class WSUWP_Graduate_Degree_Programs {
 	 */
 	public function manage_factsheet_title_update( $data, $postarr ) {
 		$user = wp_get_current_user();
-		//print user id
-		error_log( 'User ID: ' . $user->ID );	
-		error_log( 'Post ID: ' . $postarr['ID'] );
-		error_log( 'User is restricted contributor: ' . $this->user_is_restricted_contributor( $user->ID, $postarr['ID'] ) );
-		error_log( 'Data post title: ' . $data['post_title'] );
 
 		if ( isset( $postarr['ID'] ) && $this->user_is_restricted_contributor( $user->ID, $postarr['ID'] ) ) {
 			$existing_title = get_post_field( 'post_title', absint( $postarr['ID'] ) );
-			error_log( 'Existing title: ' . $existing_title );
 			if ( ! empty( $existing_title ) && $data['post_title'] !== $existing_title ) {
 				$data['post_title'] = $existing_title;
-				error_log( 'Data post title: ' . $data['post_title'] );
 			}
-			error_log( 'Data post title: ' . $data['post_title'] );
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Restores taxonomy terms if a restricted contributor tries to change them.
-	 *
-	 * This method hooks into 'set_object_terms' and restores the original terms
-	 * for Program Names and Degree Types taxonomies if the current user is a
-	 * restricted contributor.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @param int    $object_id  Object ID.
-	 * @param array  $terms      An array of object term IDs or slugs.
-	 * @param array  $tt_ids     An array of term taxonomy IDs.
-	 * @param string $taxonomy   Taxonomy slug.
-	 * @param bool   $append     Whether to append new terms to the old terms.
-	 * @param array  $old_tt_ids Old array of term taxonomy IDs.
-	 */
-	public function maybe_restore_taxonomy_terms( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
-		// Only check for our restricted taxonomies
-		$restricted_taxonomies = array( 'gs-program-name', 'gs-degree-type' );
-
-		if ( ! in_array( $taxonomy, $restricted_taxonomies, true ) ) {
-			return;
-		}
-
-		// Only check for our post type
-		if ( get_post_type( $object_id ) !== $this->post_type_slug ) {
-			return;
-		}
-
-		$user_id = get_current_user_id();
-
-		// If user is a restricted contributor, restore the old terms
-		if ( $this->user_is_restricted_contributor( $user_id, $object_id ) ) {
-			// Remove the action temporarily to avoid infinite loop
-			remove_action( 'set_object_terms', array( $this, 'maybe_restore_taxonomy_terms' ), 10 );
-
-			// Restore the old terms
-			$old_term_ids = array();
-			if ( ! empty( $old_tt_ids ) ) {
-				foreach ( $old_tt_ids as $old_tt_id ) {
-					$term = get_term_by( 'term_taxonomy_id', $old_tt_id );
-					if ( $term ) {
-						$old_term_ids[] = $term->term_id;
-					}
-				}
-			}
-
-			wp_set_object_terms( $object_id, $old_term_ids, $taxonomy );
-
-			// Re-add the action
-			add_action( 'set_object_terms', array( $this, 'maybe_restore_taxonomy_terms' ), 10, 6 );
-		}
 	}
 
 	/**

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -140,7 +140,7 @@ class WSUWP_Graduate_Degree_Programs {
 		'gsdp_locations' => array(
 			'description' => 'Locations',
 			'type' => 'locations',
-			'sanitize_callback' => 'WSUWP_Graduate_Degree_Programs::sanitize_locations',
+			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_locations',
 			'meta_field_callback' => array( __CLASS__, 'display_locations_meta_field' ),
 			'restricted' => true,
 			'pre_html' => '<div class="factsheet-group">',
@@ -159,7 +159,7 @@ class WSUWP_Graduate_Degree_Programs {
 		'gsdp_deadlines' => array(
 			'description' => 'Deadlines',
 			'type' => 'deadlines',
-			'sanitize_callback' => 'WSUWP_Graduate_Degree_Programs::sanitize_deadlines',
+			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_deadlines',
 			'meta_field_callback' => array( __CLASS__, 'display_deadlines_meta_field' ),
 			'pre_html' => '<div class="factsheet-group">',
 			'post_html' => '</div>',
@@ -168,7 +168,7 @@ class WSUWP_Graduate_Degree_Programs {
 		'gsdp_deadlines_prog' => array(
 			'description' => 'Program Deadlines',
 			'type' => 'deadlines_prog',
-			'sanitize_callback' => 'WSUWP_Graduate_Degree_Programs::sanitize_deadlines_prog',
+			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_deadlines_prog',
 			'meta_field_callback' => array( __CLASS__, 'display_deadlines_prog_meta_field' ),
 			'pre_html' => '<div class="factsheet-group">',
 			'post_html' => '</div>',
@@ -177,7 +177,7 @@ class WSUWP_Graduate_Degree_Programs {
 		'gsdp_requirements' => array(
 			'description' => 'Language Test Requirements',
 			'type' => 'requirements',
-			'sanitize_callback' => 'WSUWP_Graduate_Degree_Programs::sanitize_requirements',
+			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_requirements',
 			'meta_field_callback' => array( __CLASS__, 'display_requirements_meta_field' ),
 			'pre_html' => '<div class="factsheet-group">',
 			'post_html' => '</div>',
@@ -186,7 +186,7 @@ class WSUWP_Graduate_Degree_Programs {
 		'gsdp_requirements_gre' => array(
 			'description' => 'GRE Requirements',
 			'type' => 'requirements-gre',
-			'sanitize_callback' => 'WSUWP_Graduate_Degree_Programs::sanitize_requirements_gre',
+			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_requirements_gre',
 			'meta_field_callback' => array( __CLASS__, 'display_requirements_gre_meta_field' ),
 			'pre_html' => '<div class="factsheet-group">',
 			'post_html' => '</div>',
@@ -195,7 +195,7 @@ class WSUWP_Graduate_Degree_Programs {
 		'gsdp_contacts' => array(
 			'description' => 'Contacts',
 			'type' => 'gscontacts',
-			'sanitize_callback' => 'WSUWP_Graduate_Degree_Programs::sanitize_contacts',
+			'sanitize_callback' => 'WSUWP_Factsheet_Sanitizer::sanitize_contacts',
 			'meta_field_callback' => array( __CLASS__, 'display_contacts_meta_field' ),
 			'pre_html' => '<div class="factsheet-group">',
 			'post_html' => '</div>',
@@ -268,6 +268,7 @@ class WSUWP_Graduate_Degree_Programs {
 		require_once dirname( __FILE__ ) . '/class-factsheet-data.php';
 		require_once dirname( __FILE__ ) . '/class-factsheet-access.php';
 		require_once dirname( __FILE__ ) . '/class-factsheet-admin-assets.php';
+		require_once dirname( __FILE__ ) . '/class-factsheet-sanitizer.php';
 		$this->factsheet_redirects = new WSUWP_Factsheet_Redirects( $this->post_type_slug, $this->archive_slug );
 		$this->factsheet_archive = new WSUWP_Factsheet_Archive( $this->post_type_slug );
 		$this->factsheet_admin_assets = new WSUWP_Factsheet_Admin_Assets( $this->post_type_slug );
@@ -1064,11 +1065,7 @@ class WSUWP_Graduate_Degree_Programs {
 		<?php
 		// @codingStandardsIgnoreEnd
 	}
-
-
-
 	
-
 	/**
 	 * Outputs the meta field HTML used to capture meta data stored as strings.
 	 *
@@ -1162,285 +1159,6 @@ class WSUWP_Graduate_Degree_Programs {
 
 		return $data;
 	}
-
-	/**
-	 * Sanitizes a GPA value.
-	 *
-	 * @since 0.4.0
-	 *
-	 * @param string $gpa The unsanitized GPA.
-	 *
-	 * @return string The sanitized GPA.
-	 */
-	public static function sanitize_gpa( $gpa ) {
-		$dot_count = substr_count( $gpa, '.' );
-
-		if ( 0 === $dot_count ) {
-			$gpa = absint( $gpa ) . '.0';
-		} elseif ( 1 === $dot_count ) {
-			$gpa = explode( '.', $gpa );
-			$gpa = absint( $gpa[0] ) . '.' . absint( $gpa[1] );
-		} else {
-			$gpa = '0.0';
-		}
-
-		return $gpa;
-	}
-
-	/**
-	 * Sanitizes a set of locations stored in a string.
-	 *
-	 * @since 0.10.0
-	 *
-	 * @param array $locations
-	 *
-	 * @return array
-	 */
-	public static function sanitize_locations( $locations ) {
-		if ( ! is_array( $locations ) || 0 === count( $locations ) ) {
-			$locations = array();
-		}
-
-		$location_names = array( 'Pullman', 'Spokane', 'Tri-Cities', 'Vancouver',  'Everett','Global Campus (online)', );
-		$clean_locations = array();
-
-		foreach ( $location_names as $location_name ) {
-			if ( ! isset( $locations[ $location_name ] ) || ! in_array( $locations[ $location_name ], array( 'No', 'Yes', 'By Exception' ), true ) ) {
-				$clean_locations[ $location_name ] = 'No';
-			} else {
-				$clean_locations[ $location_name ] = $locations[ $location_name ];
-			}
-		}
-
-		return $clean_locations;
-	}
-
-	/**
-	 * Sanitizes a set of deadlines stored in a string.
-	 *
-	 * @since 0.4.0
-	 *
-	 * @param array $deadlines
-	 *
-	 * @return string
-	 */
-	public static function sanitize_deadlines( $deadlines ) {
-		if ( ! is_array( $deadlines ) || 0 === count( $deadlines ) ) {
-			return '';
-		}
-
-		$clean_deadlines = array();
-
-		foreach ( $deadlines as $deadline ) {
-			$clean_deadline = array();
-
-			if ( isset( $deadline['semester'] ) && in_array( $deadline['semester'], array( 'None', 'Fall', 'Spring', 'Summer' ), true ) ) {
-				$clean_deadline['semester'] = $deadline['semester'];
-			} else {
-				$clean_deadline['semester'] = 'None';
-			}
-
-			if ( isset( $deadline['deadline'] ) ) {
-				$clean_deadline['deadline'] = sanitize_text_field( $deadline['deadline'] );
-			} else {
-				$clean_deadline['deadline'] = '';
-			}
-
-			if ( isset( $deadline['international'] ) ) {
-				$clean_deadline['international'] = sanitize_text_field( $deadline['international'] );
-			} else {
-				$clean_deadline['international'] = '';
-			}
-
-			$clean_deadlines[] = $clean_deadline;
-		}
-
-		return $deadlines;
-	}
-
-
-	/**
-	 * Sanitizes a set of deadlines stored in a string.
-	 *
-	 * @since 0.4.0
-	 *
-	 * @param array $deadlines
-	 *
-	 * @return string
-	 */
-	public static function sanitize_deadlines_prog( $deadlines_prog ) {
-		if ( ! is_array( $deadlines_prog ) || 0 === count( $deadlines_prog ) ) {
-			return '';
-		}
-
-		$clean_deadlines_prog = array();
-
-		foreach ( $deadlines_prog as $deadline_prog ) {
-			$clean_deadline_prog = array();
-
-			if ( isset( $deadline_prog['semester'] ) && in_array( $deadline_prog['semester'], array( 'None', 'Fall', 'Spring', 'Summer' ), true ) ) {
-				$clean_deadline_prog['semester'] = $deadline_prog['semester'];
-			} else {
-				$clean_deadline_prog['semester'] = 'None';
-			}
-
-			if ( isset( $deadline_prog['deadline_prog'] ) ) {
-				$clean_deadline_prog['deadline_prog'] = sanitize_text_field( $deadline_prog['deadline_prog'] );
-			} else {
-				$clean_deadline_prog['deadline_prog'] = '';
-			}
-
-			if ( isset( $deadline_prog['international'] ) ) {
-				$clean_deadline_prog['international'] = sanitize_text_field( $deadline_prog['international'] );
-			} else {
-				$clean_deadline_prog['international'] = '';
-			}
-
-			$clean_deadlines_prog[] = $clean_deadline_prog;
-		}
-
-		return $deadlines_prog;
-	}
-
-		/**
-	 * Sanitizes a set of requirements stored in a string.
-	 *
-	 * @since 0.4.0
-	 *
-	 * @param array $requirements_gre
-	 *
-	 * @return string
-	 */
-	public static function sanitize_contacts( $contacts ) {
-		if ( ! is_array( $contacts ) || 0 === count( $contacts ) ) {
-			return '';
-		}
-
-		$clean_contacts = array();
-
-		foreach ( $contacts as $contact ) {
-			$clean_contact = array();
-
-			if ( isset( $contact['name'] ) ) {
-				$clean_contact['name'] = sanitize_text_field( $contact['name'] );
-			} else {
-				$clean_contact['name'] = '';
-			}
-
-			if ( isset( $contact['email'] ) ) {
-				$clean_contact['email'] = sanitize_text_field( $contact['email'] );
-			} else {
-				$clean_contact['email'] = '';
-			}
-
-			// if ( isset( $contact['required'] ) && in_array( $contact['required'], array('None','Optional', 'Yes', 'No'), true ) ) {
-			// 	$clean_contact['required'] = $contact['required'];
-			// } else {
-			// 	$clean_contact['required'] = 'None';
-			// }
-
-			$clean_contacts[] = $clean_contact;
-		}
-
-		return $clean_contacts;
-	}
-
-
-
-	/**
-	 * Sanitizes a set of requirements stored in a string.
-	 *
-	 * @since 0.4.0
-	 *
-	 * @param array $requirements_gre
-	 *
-	 * @return string
-	 */
-	public static function sanitize_requirements_gre( $requirements_gre ) {
-		if ( ! is_array( $requirements_gre ) || 0 === count( $requirements_gre ) ) {
-			return '';
-		}
-
-		$clean_requirements = array();
-
-		foreach ( $requirements_gre as $requirement ) {
-			$clean_requirement = array();
-
-			// if ( isset( $requirement['score'] ) ) {
-			// 	$clean_requirement['score'] = sanitize_text_field( $requirement['score'] );
-			// } else {
-			// 	$clean_requirement['score'] = '';
-			// }
-
-			if ( isset( $requirement['test'] ) ) {
-				$clean_requirement['test'] = sanitize_text_field( $requirement['test'] );
-			} else {
-				$clean_requirement['test'] = '';
-			}
-
-			if ( isset( $requirement['required'] ) && in_array( $requirement['required'], array('None','Optional', 'Yes', 'No'), true ) ) {
-				$clean_requirement['required'] = $requirement['required'];
-			} else {
-				$clean_requirement['required'] = 'None';
-			}
-
-			// if ( isset( $requirement['description'] ) ) {
-			// 	$clean_requirement['description'] = sanitize_text_field( $requirement['description'] );
-			// } else {
-			// 	$clean_requirement['description'] = '';
-			// }
-
-			$clean_requirements[] = $clean_requirement;
-		}
-
-		return $clean_requirements;
-	}
-
-
-
-	/**
-	 * Sanitizes a set of requirements stored in a string.
-	 *
-	 * @since 0.4.0
-	 *
-	 * @param array $requirements
-	 *
-	 * @return string
-	 */
-	public static function sanitize_requirements( $requirements ) {
-		if ( ! is_array( $requirements ) || 0 === count( $requirements ) ) {
-			return '';
-		}
-
-		$clean_requirements = array();
-
-		foreach ( $requirements as $requirement ) {
-			$clean_requirement = array();
-
-			if ( isset( $requirement['score'] ) ) {
-				$clean_requirement['score'] = sanitize_text_field( $requirement['score'] );
-			} else {
-				$clean_requirement['score'] = '';
-			}
-
-			if ( isset( $requirement['test'] ) ) {
-				$clean_requirement['test'] = sanitize_text_field( $requirement['test'] );
-			} else {
-				$clean_requirement['test'] = '';
-			}
-
-			if ( isset( $requirement['description'] ) ) {
-				$clean_requirement['description'] = sanitize_text_field( $requirement['description'] );
-			} else {
-				$clean_requirement['description'] = '';
-			}
-
-			$clean_requirements[] = $clean_requirement;
-		}
-
-		return $clean_requirements;
-	}
-
 
 	/**
 	 * Save additional data associated with a factsheet.

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -302,11 +302,14 @@ class WSUWP_Graduate_Degree_Programs {
 
 			wp_enqueue_script( 'gsdp-factsheet-admin' );
 
-			// Disable title and permalink for restricted contributors
+			// Disable title and permalink for restricted contributors (only on published posts, not new/draft ones)
 			$user_id = get_current_user_id();
 			$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$post_status = get_post_status( $post_id );
+			$is_new_or_draft = empty( $post_id ) || in_array( $post_status, array( 'auto-draft', 'draft' ), true );
 
-			if ( $this->user_is_restricted_contributor( $user_id, $post_id ) ) {
+			// Only apply restrictions when editing published factsheets, not when creating new ones or editing drafts
+			if ( ! $is_new_or_draft && $this->user_is_restricted_contributor( $user_id, $post_id ) ) {
 				// Add inline CSS to visually disable restricted fields
 				$custom_css = '
 					/* Disable title field */
@@ -1231,14 +1234,17 @@ class WSUWP_Graduate_Degree_Programs {
 	 * - They are assigned via Editorial Access Manager (EAM), OR
 	 * - They have a WordPress role of 'contributor', 'author', or 'editor' (only 'administrator' has full access)
 	 *
-	 * Restricted users cannot edit:
+	 * Restricted users cannot edit (on existing factsheets only):
 	 * - Factsheet title
 	 * - Factsheet display name
 	 * - Include in programs list
 	 * - Program Names taxonomy
 	 * - Degree Types taxonomy
 	 *
+	 * Note: No restrictions apply when creating a NEW factsheet or editing a DRAFT - all fields are editable.
+	 *
 	 * @since 1.4.0
+	 * @since 1.5.0 Added check for new posts and drafts - no restrictions until published.
 	 *
 	 * @param int      $user_id The user ID to check.
 	 * @param int|null $post_id Optional. The post ID for EAM check.
@@ -1246,6 +1252,12 @@ class WSUWP_Graduate_Degree_Programs {
 	 * @return bool True if the user is a restricted contributor, false otherwise.
 	 */
 	public function user_is_restricted_contributor( $user_id, $post_id = null ) {
+		// No restrictions for new posts or drafts - allow full access when creating/drafting a factsheet
+		$post_status = $post_id ? get_post_status( $post_id ) : '';
+		if ( empty( $post_id ) || in_array( $post_status, array( 'auto-draft', 'draft' ), true ) ) {
+			return false;
+		}
+
 		// Check EAM assignment (if post_id provided)
 		if ( $post_id && $this->user_is_eam_user( $user_id, $post_id ) ) {
 			return true;

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -63,6 +63,7 @@ class WSUWP_Graduate_Degree_Programs {
 			'type' => 'bool',
 			'sanitize_callback' => 'absint',
 			'meta_field_callback' => array( __CLASS__, 'display_bool_meta_field' ),
+			'restricted' => true,
 			'location' => 'primary',
 		),
 		'gsdp_grad_students_total' => array(
@@ -268,11 +269,11 @@ class WSUWP_Graduate_Degree_Programs {
 		add_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 200, 4 );
 
 		// Several fields are restricted to full editors or admins.
-		// add_filter( "auth_post_{$this->post_type_slug}_meta_gsdp_degree_id", array( $this, 'can_edit_restricted_field' ), 100, 4 );
-		add_filter( "auth_post_{$this->post_type_slug}_meta_gsdp_degree_shortname", array( $this, 'can_edit_restricted_field' ), 100, 4 );
-		add_filter( "auth_post_{$this->post_type_slug}_meta_gsdp_student_learning_outcome", array( $this, 'can_edit_restricted_field' ), 100, 4 );
-		add_filter( "auth_post_{$this->post_type_slug}_meta_gsdp_include_in_programs", array( $this, 'can_edit_restricted_field' ), 100, 4 );
-
+		// Updated to use new filter format (since WP 4.9.8): auth_post_meta_{meta_key}_for_{post_type}
+		// add_filter( "auth_post_meta_gsdp_degree_id_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
+		add_filter( "auth_post_meta_gsdp_degree_shortname_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
+		add_filter( "auth_post_meta_gsdp_student_learning_outcome_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
+		add_filter( "auth_post_meta_gsdp_include_in_programs_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
 		add_filter( 'wp_insert_post_data', array( $this, 'manage_factsheet_title_update' ), 10, 2 );
 
 		// Block taxonomy term assignment for restricted contributors.
@@ -289,6 +290,7 @@ class WSUWP_Graduate_Degree_Programs {
 	 * Enqueue scripts and styles used in the admin.
 	 *
 	 * @since 0.4.0
+	 * @since 1.4.0 Added inline styles to disable title/permalink for restricted contributors.
 	 *
 	 * @param string $hook_suffix
 	 */
@@ -302,6 +304,76 @@ class WSUWP_Graduate_Degree_Programs {
 			wp_register_script( 'gsdp-factsheet-admin', WSUWP\Plugin\Graduate\Plugin::get('url'). '/js/factsheet-admin.min.js', array( 'jquery', 'underscore', 'jquery-ui-autocomplete' ), WSUWP_Graduate_School_Theme()->theme_version(), true );
 
 			wp_enqueue_script( 'gsdp-factsheet-admin' );
+
+			// Disable title and permalink for restricted contributors
+			$user_id = get_current_user_id();
+			$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+			if ( $this->user_is_restricted_contributor( $user_id, $post_id ) ) {
+				// Add inline CSS to visually disable restricted fields
+				$custom_css = '
+					/* Disable title field */
+					#titlewrap input#title {
+						pointer-events: none;
+						background-color: #f0f0f0;
+						color: #666;
+						cursor: not-allowed;
+					}
+					/* Disable permalink edit */
+					#edit-slug-box,
+					#edit-slug-buttons,
+					.edit-slug {
+						pointer-events: none;
+						opacity: 0.5;
+					}
+					#edit-slug-buttons {
+						display: none;
+					}
+					/* Disable Program Names panel (greyed out) */
+					#gs-program-namediv {
+						pointer-events: none;
+						opacity: 0.5;
+					}
+					#gs-program-namediv .inside {
+						background-color: #f0f0f0;
+					}
+					#gs-program-namediv input,
+					#gs-program-namediv select,
+					#gs-program-namediv button {
+						cursor: not-allowed;
+					}
+					/* Disable Degree Types panel (greyed out) */
+					#tagsdiv-gs-degree-type {
+						pointer-events: none;
+						opacity: 0.5;
+					}
+					#tagsdiv-gs-degree-type .inside {
+						background-color: #f0f0f0;
+					}
+					#tagsdiv-gs-degree-type input,
+					#tagsdiv-gs-degree-type select,
+					#tagsdiv-gs-degree-type button {
+						cursor: not-allowed;
+					}
+				';
+				wp_add_inline_style( 'gsdp-admin', $custom_css );
+
+				// Add inline JS to make fields readonly/disabled
+				$custom_js = '
+					jQuery(document).ready(function($) {
+						// Make title readonly
+						$("#title").prop("readonly", true);
+						// Disable permalink edit button
+						$("#edit-slug-buttons .edit-slug").remove();
+						$(".edit-slug").remove();
+						// Disable inputs in Program Names panel
+						$("#gs-program-namediv input, #gs-program-namediv select, #gs-program-namediv button").prop("disabled", true);
+						// Disable inputs in Degree Types panel
+						$("#tagsdiv-gs-degree-type input, #tagsdiv-gs-degree-type select, #tagsdiv-gs-degree-type button").prop("disabled", true);
+					});
+				';
+				wp_add_inline_script( 'gsdp-factsheet-admin', $custom_js );
+			}
 		}
 
 		if ( in_array( $hook_suffix, array( 'edit-tags.php', 'term.php', 'term-new.php' ), true ) && in_array( get_current_screen()->taxonomy, array( 'gs-degree-type' ), true ) ) {
@@ -412,15 +484,14 @@ class WSUWP_Graduate_Degree_Programs {
 	}
 
 	/**
-	 * Removes the faculty member and contact info taxonomy boxes from the
-	 * factsheet screen. This data is managed via custom input in the primary
-	 * meta box.
+	 * Removes unnecessary meta boxes from the factsheet screen.
 	 *
-	 * Also removes Program Names and Degree Types taxonomy boxes for restricted
-	 * contributors (EAM-assigned users or users with contributor/author roles).
+	 * Note: Program Names and Degree Types taxonomy boxes are NOT removed here.
+	 * They are greyed out (disabled) via CSS/JS in admin_enqueue_scripts() for
+	 * restricted contributors.
 	 *
 	 * @since 0.7.0
-	 * @since 1.4.0 Added removal of taxonomy boxes for restricted contributors.
+	 * @since 1.4.0 Taxonomy boxes now greyed out instead of removed.
 	 *
 	 * @param string $post_type
 	 */
@@ -430,15 +501,6 @@ class WSUWP_Graduate_Degree_Programs {
 		}
 
 		remove_meta_box( 'wpseo_meta', $this->post_type_slug, 'normal' );
-
-		// Remove taxonomy meta boxes for restricted contributors
-		$user_id = get_current_user_id();
-		$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-		if ( $this->user_is_restricted_contributor( $user_id, $post_id ) ) {
-			remove_meta_box( 'gs-program-namediv', $this->post_type_slug, 'side' );
-			remove_meta_box( 'gs-degree-typediv', $this->post_type_slug, 'side' );
-		}
 	}
 
 	/**
@@ -566,7 +628,8 @@ class WSUWP_Graduate_Degree_Programs {
 		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
 		<?php
 
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
+		// Check if field is restricted and user is a restricted contributor
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
 			$disabled = 'disabled';
 		} else {
 			$disabled = '';
@@ -591,7 +654,8 @@ class WSUWP_Graduate_Degree_Programs {
 		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
 		<?php
 
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
+		// Check if field is restricted and user is a restricted contributor
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
 			$disabled = 'disabled';
 		} else {
 			$disabled = '';
@@ -606,15 +670,23 @@ class WSUWP_Graduate_Degree_Programs {
 	 * Outputs the meta field HTML used to capture meta data stored as boolean.
 	 *
 	 * @since 1.3.0
+	 * @since 1.4.0 Added support for restricted fields that are disabled for contributors.
 	 *
 	 * @param array  $meta
 	 * @param string $key
 	 * @param array  $data
 	 */
 	public function display_bool_meta_field( $meta, $key, $data ) {
+		// Check if field is restricted and user is a restricted contributor
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
+			$disabled = 'disabled';
+		} else {
+			$disabled = '';
+		}
+
 		?>
 		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
-		<select name="<?php echo esc_attr( $key ); ?>">
+		<select name="<?php echo esc_attr( $key ); ?>" <?php echo $disabled; // @codingStandardsIgnoreLine ?>>
 			<option value="0" <?php selected( 0, absint( $data[ $key ][0] ) ); ?>>No</option>
 			<option value="1" <?php selected( 1, absint( $data[ $key ][0] ) ); ?>>Yes</option>
 		</select>
@@ -1146,6 +1218,8 @@ class WSUWP_Graduate_Degree_Programs {
 
 		if ( 'users' === $enable_custom_access ) {
 			$allowed_users = (array) get_post_meta( $post_id, 'eam_allowed_users', true );
+			//log allowed users
+			error_log( print_r( $allowed_users, true ) );
 
 			if ( in_array( $user_id, $allowed_users ) ) { // @codingStandardsIgnoreLine (Converting user IDs to ints is not worth it)
 				return true;
@@ -1160,7 +1234,14 @@ class WSUWP_Graduate_Degree_Programs {
 	 *
 	 * A user is considered a restricted contributor if:
 	 * - They are assigned via Editorial Access Manager (EAM), OR
-	 * - They have a WordPress role of 'contributor' or 'author' (and not 'administrator' or 'editor')
+	 * - They have a WordPress role of 'contributor', 'author', or 'editor' (only 'administrator' has full access)
+	 *
+	 * Restricted users cannot edit:
+	 * - Factsheet title
+	 * - Factsheet display name
+	 * - Include in programs list
+	 * - Program Names taxonomy
+	 * - Degree Types taxonomy
 	 *
 	 * @since 1.4.0
 	 *
@@ -1177,8 +1258,10 @@ class WSUWP_Graduate_Degree_Programs {
 
 		// Check WordPress role
 		$user = new WP_User( $user_id );
-		$restricted_roles = array( 'contributor', 'author' );
-		$unrestricted_roles = array( 'administrator', 'editor' );
+		// Editors, Authors, and Contributors have restricted access to certain fields
+		$restricted_roles = array( 'contributor', 'author', 'editor' );
+		// Only Administrators have full unrestricted access
+		$unrestricted_roles = array( 'administrator' );
 
 		// If user has an unrestricted role, they are not a restricted contributor
 		foreach ( $unrestricted_roles as $role ) {
@@ -1240,13 +1323,20 @@ class WSUWP_Graduate_Degree_Programs {
 	 */
 	public function manage_factsheet_title_update( $data, $postarr ) {
 		$user = wp_get_current_user();
+		//print user id
+		error_log( 'User ID: ' . $user->ID );	
+		error_log( 'Post ID: ' . $postarr['ID'] );
+		error_log( 'User is restricted contributor: ' . $this->user_is_restricted_contributor( $user->ID, $postarr['ID'] ) );
+		error_log( 'Data post title: ' . $data['post_title'] );
 
 		if ( isset( $postarr['ID'] ) && $this->user_is_restricted_contributor( $user->ID, $postarr['ID'] ) ) {
 			$existing_title = get_post_field( 'post_title', absint( $postarr['ID'] ) );
-
+			error_log( 'Existing title: ' . $existing_title );
 			if ( ! empty( $existing_title ) && $data['post_title'] !== $existing_title ) {
 				$data['post_title'] = $existing_title;
+				error_log( 'Data post title: ' . $data['post_title'] );
 			}
+			error_log( 'Data post title: ' . $data['post_title'] );
 		}
 
 		return $data;

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -265,8 +265,8 @@ class WSUWP_Graduate_Degree_Programs {
 		add_action( 'add_meta_boxes', array( $this, 'remove_meta_boxes' ), 99 );
 		add_action( "save_post_{$this->post_type_slug}", array( $this, 'save_factsheet' ), 10, 2 );
 
-		// This should fire after the filter in Editorial Access Manager.
-		add_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 200, 4 );
+		// Capability mapping for team-based access is now handled by
+		// \WSUWP\Plugin\Graduate\Factsheet_Team::map_meta_cap() at priority 150.
 
 		// Several fields are restricted to full editors or admins.
 		// Updated to use new filter format (since WP 4.9.8): auth_post_meta_{meta_key}_for_{post_type}
@@ -501,6 +501,9 @@ class WSUWP_Graduate_Degree_Programs {
 		}
 
 		remove_meta_box( 'wpseo_meta', $this->post_type_slug, 'normal' );
+
+		// Team management is handled by Factsheet_Team; remove the EAM meta box if the plugin is active.
+		remove_meta_box( 'eam_access_manager', $this->post_type_slug, 'side' );
 	}
 
 	/**
@@ -1204,9 +1207,13 @@ class WSUWP_Graduate_Degree_Programs {
 	}
 
 	/**
-	 * Determines if a user has been assigned to a factsheet through Editorial Access Manager.
+	 * Determines if a user has been assigned to a factsheet as a team member.
+	 *
+	 * Delegates to {@see \WSUWP\Plugin\Graduate\Factsheet_Team::is_team_member()}
+	 * which also provides backward compatibility with legacy EAM post meta.
 	 *
 	 * @since 1.1.0
+	 * @since 1.3.0 Now delegates to the Factsheet_Team class instead of reading EAM meta directly.
 	 *
 	 * @param int $user_id
 	 * @param int $post_id
@@ -1214,24 +1221,14 @@ class WSUWP_Graduate_Degree_Programs {
 	 * @return bool
 	 */
 	public function user_is_eam_user( $user_id, $post_id ) {
-		$enable_custom_access = get_post_meta( $post_id, 'eam_enable_custom_access', true );
-
-		if ( 'users' === $enable_custom_access ) {
-			$allowed_users = (array) get_post_meta( $post_id, 'eam_allowed_users', true );
-
-			if ( in_array( $user_id, $allowed_users ) ) { // @codingStandardsIgnoreLine (Converting user IDs to ints is not worth it)
-				return true;
-			}
-		}
-
-		return false;
+		return \WSUWP\Plugin\Graduate\Factsheet_Team::is_team_member( $user_id, $post_id );
 	}
 
 	/**
 	 * Determines if a user is a restricted contributor.
 	 *
 	 * A user is considered a restricted contributor if:
-	 * - They are assigned via Editorial Access Manager (EAM), OR
+	 * - They are assigned as a am to have 2 member, OR
 	 * - They have a WordPress role of 'contributor', 'author', or 'editor' (only 'administrator' has full access)
 	 *
 	 * Restricted users cannot edit (on existing factsheets only):
@@ -1245,9 +1242,10 @@ class WSUWP_Graduate_Degree_Programs {
 	 *
 	 * @since 1.4.0
 	 * @since 1.5.0 Added check for new posts and drafts - no restrictions until published.
+	 * @since 1.6.0 Now uses Factsheet_Team for team membership instead of EAM.
 	 *
 	 * @param int      $user_id The user ID to check.
-	 * @param int|null $post_id Optional. The post ID for EAM check.
+	 * @param int|null $post_id Optional. The post ID for team membership check.
 	 *
 	 * @return bool True if the user is a restricted contributor, false otherwise.
 	 */
@@ -1291,7 +1289,7 @@ class WSUWP_Graduate_Degree_Programs {
 	 * Ensures that restricted contributors are not allowed to change restricted fields.
 	 *
 	 * Restricted contributors include:
-	 * - Users assigned via Editorial Access Manager (EAM)
+	 * - Users assigned as factsheet team members
 	 * - Users with WordPress contributor or author roles
 	 *
 	 * @since 1.1.0
@@ -1317,7 +1315,7 @@ class WSUWP_Graduate_Degree_Programs {
 	 * Prevents restricted contributors from editing a factsheet's title.
 	 *
 	 * Restricted contributors include:
-	 * - Users assigned via Editorial Access Manager (EAM)
+	 * - Users assigned as factsheet team members
 	 * - Users with WordPress contributor or author roles
 	 *
 	 * @since 1.1.0
@@ -1680,59 +1678,15 @@ class WSUWP_Graduate_Degree_Programs {
 	}
 
 	/**
-	 * Filters a user's ability to delete factsheets when they have been added as an
-	 * authorized user via Editorial Access Manager.
+	 * Deprecated. Capability mapping is now handled by
+	 * {@see \WSUWP\Plugin\Graduate\Factsheet_Team::map_meta_cap()}.
+	 *
+	 * Kept for reference; the filter hook has been removed from setup_hooks().
 	 *
 	 * @since 1.1.0
-	 *
-	 * @param array $caps
-	 * @param string $cap
-	 * @param int $user_id
-	 * @param array $args
-	 *
-	 * @return array
+	 * @deprecated 1.3.0
 	 */
 	public function filter_map_meta_cap( $caps, $cap, $user_id, $args ) {
-		$eam_caps = array(
-			'delete_page',
-			'delete_post',
-		);
-
-		if ( in_array( $cap, $eam_caps, true ) ) {
-
-			$post_id = ( isset( $args[0] ) ) ? (int) $args[0] : null;
-			if ( ! $post_id && ! empty( $_GET['post'] ) ) { // WPCS: CSRF Ok.
-				$post_id = (int) $_GET['post'];
-			}
-
-			if ( ! $post_id && ! empty( $_POST['post_ID'] ) ) { // @codingStandardsIgnoreLine (No reason to check a nonce here)
-				$post_id = (int) $_POST['post_ID'];
-			}
-
-			if ( ! $post_id ) {
-				return $caps;
-			}
-
-			$enable_custom_access = get_post_meta( $post_id, 'eam_enable_custom_access', true );
-
-			if ( ! empty( $enable_custom_access ) ) {
-				$user = new WP_User( $user_id );
-
-				// If user is admin, we do nothing
-				if ( ! in_array( 'administrator', $user->roles, true ) ) {
-
-					if ( 'users' === $enable_custom_access ) {
-						// Reset caps for allowed users to do_not_allow.
-						$allowed_users = (array) get_post_meta( $post_id, 'eam_allowed_users', true );
-
-						if ( in_array( $user_id, $allowed_users ) ) { // @codingStandardsIgnoreLine (Converting user IDs to ints is not worth it)
-							$caps[] = 'do_not_allow';
-						}
-					}
-				}
-			}
-		}
-
 		return $caps;
 	}
 

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -2,6 +2,10 @@
 
 class WSUWP_Graduate_Degree_Programs {
 	/**
+	 * @var WSUWP_Factsheet_Redirects
+	 */
+	private $factsheet_redirects;
+	/**
 	 * @since 0.4.0
 	 *
 	 * @var WSUWP_Graduate_Degree_Programs
@@ -250,6 +254,8 @@ class WSUWP_Graduate_Degree_Programs {
 	public function setup_hooks() {
 		require_once dirname( __FILE__ ) . '/class-graduate-degree-program-name-taxonomy.php';
 		require_once dirname( __FILE__ ) . '/class-graduate-degree-degree-type-taxonomy.php';
+		require_once dirname( __FILE__ ) . '/class-factsheet-redirects.php';
+		$this->factsheet_redirects = new WSUWP_Factsheet_Redirects( $this->post_type_slug, $this->archive_slug );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 
@@ -277,8 +283,8 @@ class WSUWP_Graduate_Degree_Programs {
 		add_filter( 'wp_insert_post_data', array( $this, 'manage_factsheet_title_update' ), 10, 2 );
 
 		add_action( 'pre_get_posts', array( $this, 'adjust_factsheet_archive_query' ) );
-		add_action( 'template_redirect', array( $this, 'redirect_old_factsheet_urls' ) );
-		add_action( 'template_redirect', array( $this, 'redirect_private_factsheets' ) );
+		add_action( 'template_redirect', array( $this->factsheet_redirects, 'redirect_old_factsheet_urls' ) );
+		add_action( 'template_redirect', array( $this->factsheet_redirects, 'redirect_private_factsheets' ) );
 
 		add_filter( 'spine_get_title', array( $this, 'filter_factsheet_archive_title' ), 10, 3 );
 	}
@@ -1881,71 +1887,16 @@ class WSUWP_Graduate_Degree_Programs {
 			$query->set( 'posts_per_page', -1 );
 		}
 	}
-
 	/**
-	 * Redirects a given degree ID to either the current degree URL or
-	 * to the degrees landing page.
+	 * Redirects a factsheet ID to its corresponding URL.
+	 *
+	 * @since 0.10.0
 	 *
 	 * @param int $degree_id
 	 */
 	public function redirect_factsheet_id( $degree_id ) {
-		$matches = get_posts( array(
-			'post_type' => $this->post_type_slug,
-			'meta_key' => 'gsdp_degree_id',
-			'meta_value' => $degree_id,
-		) );
-
-		if ( 0 !== count( $matches ) ) {
-			$redirect_url = get_permalink( $matches[0]->ID );
-			wp_safe_redirect( $redirect_url, 301 );
-			exit();
-		} else {
-			wp_safe_redirect( home_url( '/' . $this->archive_slug . '/' ), 302 );
-			exit();
-		}
+		$this->factsheet_redirects->redirect_factsheet_id( $degree_id );
 	}
-
-	/**
-	 * Redirects old factsheet ID URLs to their new URL or to the
-	 * factsheets landing page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @global WP_Query $wp_query
-	 */
-	public function redirect_old_factsheet_urls() {
-		global $wp_query;
-
-		if ( $wp_query->is_404() && isset( $wp_query->query['post_type'] ) && $this->post_type_slug === $wp_query->query['post_type'] ) {
-			if ( is_numeric( $wp_query->query[ $this->post_type_slug ] ) ) {
-				$degree_id = absint( $wp_query->query[ $this->post_type_slug ] );
-				$this->redirect_factsheet_id( $degree_id );
-			}
-		}
-	}
-
-	/**
-	 * Redirects published factsheets that are set to not be included in the
-	 * program list. If the factsheet is a draft, then it can be previewed by
-	 * those who have access.
-	 *
-	 * @since 0.10.0
-	 */
-	public function redirect_private_factsheets() {
-		if ( ! is_singular( $this->post_type_slug ) ) {
-			return;
-		}
-
-		if ( 'draft' === get_post_status( get_the_ID() ) ) {
-			return;
-		}
-
-		// if ( 1 !== absint( get_post_meta( get_the_ID(), 'gsdp_include_in_programs', true ) ) ) {
-		// 	wp_redirect( home_url( '/' . $this->archive_slug . '/' ) );
-		// 	exit();
-		// }
-	}
-
 	/**
 	 * Alters the title displayed for the factsheets landing page.
 	 *

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -6,6 +6,10 @@ class WSUWP_Graduate_Degree_Programs {
 	 */
 	private $factsheet_redirects;
 	/**
+	 * @var WSUWP_Factsheet_Archive
+	 */
+	private $factsheet_archive;
+	/**
 	 * @since 0.4.0
 	 *
 	 * @var WSUWP_Graduate_Degree_Programs
@@ -255,7 +259,10 @@ class WSUWP_Graduate_Degree_Programs {
 		require_once dirname( __FILE__ ) . '/class-graduate-degree-program-name-taxonomy.php';
 		require_once dirname( __FILE__ ) . '/class-graduate-degree-degree-type-taxonomy.php';
 		require_once dirname( __FILE__ ) . '/class-factsheet-redirects.php';
+		require_once dirname( __FILE__ ) . '/class-factsheet-archive.php';
 		$this->factsheet_redirects = new WSUWP_Factsheet_Redirects( $this->post_type_slug, $this->archive_slug );
+		$this->factsheet_archive = new WSUWP_Factsheet_Archive( $this->post_type_slug );
+
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 
@@ -263,8 +270,8 @@ class WSUWP_Graduate_Degree_Programs {
 		add_action( 'init', 'WSUWP_Graduate_Degree_Program_Name_Taxonomy', 15 );
 		add_action( 'init', 'WSUWP_Graduate_Degree_Degree_Type_Taxonomy', 15 );
 
-		add_filter( 'query_vars', array( $this, 'add_gradfair_query_var' ) );
-		add_action( 'init', array( $this, 'register_mirror_menu' ) );
+		add_filter( 'query_vars', array( $this->factsheet_archive, 'add_gradfair_query_var' ) );
+		add_action( 'init', array( $this->factsheet_archive, 'register_mirror_menu' ) );
 
 		add_action( 'init', array( $this, 'register_meta' ) );
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ) );
@@ -282,11 +289,11 @@ class WSUWP_Graduate_Degree_Programs {
 		add_filter( "auth_post_meta_gsdp_include_in_programs_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
 		add_filter( 'wp_insert_post_data', array( $this, 'manage_factsheet_title_update' ), 10, 2 );
 
-		add_action( 'pre_get_posts', array( $this, 'adjust_factsheet_archive_query' ) );
+		add_action( 'pre_get_posts', array( $this->factsheet_archive, 'adjust_factsheet_archive_query' ) );
 		add_action( 'template_redirect', array( $this->factsheet_redirects, 'redirect_old_factsheet_urls' ) );
 		add_action( 'template_redirect', array( $this->factsheet_redirects, 'redirect_private_factsheets' ) );
 
-		add_filter( 'spine_get_title', array( $this, 'filter_factsheet_archive_title' ), 10, 3 );
+		add_filter( 'spine_get_title', array( $this->factsheet_archive, 'filter_factsheet_archive_title' ), 10, 3 );
 	}
 
 	/**
@@ -426,34 +433,6 @@ class WSUWP_Graduate_Degree_Programs {
 		register_post_type( $this->post_type_slug, $args );
 	}
 
-
-	/**
-	 * Add our custom query variable to the set of default query variables.
-	 *
-	 * @since 1.4.0
-	 *
-	 * @param array $vars
-	 *
-	 * @return array
-	 */
-	public function add_gradfair_query_var( $vars ) {
-		$vars[] = 'gradfair';
-
-		return $vars;
-	}
-
-	/**
-	 * Register a mirror navigation area for grad fair usage.
-	 *
-	 * @since 1.4.0
-	 */
-	public function register_mirror_menu() {
-		register_nav_menus(
-			array(
-				'gradfair'    => 'WSU Grad Fair',
-			)
-		);
-	}
 
 	/**
 	 * Register the meta keys used to store degree factsheet data.
@@ -1876,18 +1855,6 @@ class WSUWP_Graduate_Degree_Programs {
 	}
 
 	/**
-	 * Adjusts the archive query for factsheets to show all factsheets.
-	 *
-	 * @since 0.8.0
-	 *
-	 * @param WP_Query $query
-	 */
-	public function adjust_factsheet_archive_query( $query ) {
-		if ( is_post_type_archive( $this->post_type_slug ) ) {
-			$query->set( 'posts_per_page', -1 );
-		}
-	}
-	/**
 	 * Redirects a factsheet ID to its corresponding URL.
 	 *
 	 * @since 0.10.0
@@ -1896,23 +1863,5 @@ class WSUWP_Graduate_Degree_Programs {
 	 */
 	public function redirect_factsheet_id( $degree_id ) {
 		$this->factsheet_redirects->redirect_factsheet_id( $degree_id );
-	}
-	/**
-	 * Alters the title displayed for the factsheets landing page.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param string $view_title
-	 * @param string $site_title
-	 * @param string $global_title
-	 *
-	 * @return string
-	 */
-	public function filter_factsheet_archive_title( $view_title, $site_title, $global_title ) {
-		if ( is_post_type_archive( $this->post_type_slug ) ) {
-			return 'Graduate Degree Programs | ' . $site_title . $global_title;
-		}
-
-		return $view_title;
 	}
 }

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -261,6 +261,7 @@ class WSUWP_Graduate_Degree_Programs {
 		require_once dirname( __FILE__ ) . '/class-factsheet-redirects.php';
 		require_once dirname( __FILE__ ) . '/class-factsheet-archive.php';
 		require_once dirname( __FILE__ ) . '/class-factsheet-data.php';
+		require_once dirname( __FILE__ ) . '/class-factsheet-access.php';
 		$this->factsheet_redirects = new WSUWP_Factsheet_Redirects( $this->post_type_slug, $this->archive_slug );
 		$this->factsheet_archive = new WSUWP_Factsheet_Archive( $this->post_type_slug );
 
@@ -285,9 +286,9 @@ class WSUWP_Graduate_Degree_Programs {
 		// Several fields are restricted to full editors or admins.
 		// Updated to use new filter format (since WP 4.9.8): auth_post_meta_{meta_key}_for_{post_type}
 		// add_filter( "auth_post_meta_gsdp_degree_id_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
-		add_filter( "auth_post_meta_gsdp_degree_shortname_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
-		add_filter( "auth_post_meta_gsdp_student_learning_outcome_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
-		add_filter( "auth_post_meta_gsdp_include_in_programs_for_{$this->post_type_slug}", array( $this, 'can_edit_restricted_field' ), 100, 4 );
+		add_filter( "auth_post_meta_gsdp_degree_shortname_for_{$this->post_type_slug}", array( 'WSUWP_Factsheet_Access', 'can_edit_restricted_field' ), 100, 4 );
+		add_filter( "auth_post_meta_gsdp_student_learning_outcome_for_{$this->post_type_slug}", array( 'WSUWP_Factsheet_Access', 'can_edit_restricted_field' ), 100, 4 );
+		add_filter( "auth_post_meta_gsdp_include_in_programs_for_{$this->post_type_slug}", array( 'WSUWP_Factsheet_Access', 'can_edit_restricted_field' ), 100, 4 );
 		add_filter( 'wp_insert_post_data', array( $this, 'manage_factsheet_title_update' ), 10, 2 );
 
 		add_action( 'pre_get_posts', array( $this->factsheet_archive, 'adjust_factsheet_archive_query' ) );
@@ -323,7 +324,7 @@ class WSUWP_Graduate_Degree_Programs {
 			$is_new_or_draft = empty( $post_id ) || in_array( $post_status, array( 'auto-draft', 'draft' ), true );
 
 			// Only apply restrictions when editing published factsheets, not when creating new ones or editing drafts
-			if ( ! $is_new_or_draft && $this->user_is_restricted_contributor( $user_id, $post_id ) ) {
+			if ( ! $is_new_or_draft && WSUWP_Factsheet_Access::user_is_restricted_contributor( $user_id, $post_id ) ) {
 				// Add inline CSS to visually disable restricted fields
 				$custom_css = '
 					/* Disable title field */
@@ -618,7 +619,7 @@ class WSUWP_Graduate_Degree_Programs {
 		<?php
 
 		// Check if field is restricted and user is a restricted contributor
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
 			$disabled = 'disabled';
 		} else {
 			$disabled = '';
@@ -644,7 +645,7 @@ class WSUWP_Graduate_Degree_Programs {
 		<?php
 
 		// Check if field is restricted and user is a restricted contributor
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
 			$disabled = 'disabled';
 		} else {
 			$disabled = '';
@@ -667,7 +668,7 @@ class WSUWP_Graduate_Degree_Programs {
 	 */
 	public function display_bool_meta_field( $meta, $key, $data ) {
 		// Check if field is restricted and user is a restricted contributor
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_restricted_contributor( wp_get_current_user()->ID, get_the_ID() ) ) {
 			$disabled = 'disabled';
 		} else {
 			$disabled = '';
@@ -696,7 +697,7 @@ class WSUWP_Graduate_Degree_Programs {
 		<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $meta['description'] ); ?>:</label>
 		<?php
 
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
 			echo '<div id="' . esc_attr( $key ) . '" class="field-content">' . wp_kses_post( apply_filters( 'the_content', $data[ $key ][0] ) ) . '</div>';
 			return;
 		}
@@ -1153,7 +1154,7 @@ class WSUWP_Graduate_Degree_Programs {
 		);
 		$field_data = wp_parse_args( $field_data, $default_field_data );
 
-		if ( isset( $meta['restricted'] ) && $meta['restricted'] && $this->user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
+		if ( isset( $meta['restricted'] ) && $meta['restricted'] && WSUWP_Factsheet_Access::user_is_eam_user( wp_get_current_user()->ID, get_the_ID() ) ) {
 			$restricted = true;
 		} else {
 			$restricted = false;
@@ -1193,111 +1194,6 @@ class WSUWP_Graduate_Degree_Programs {
 	}
 
 	/**
-	 * Determines if a user has been assigned to a factsheet as a team member.
-	 *
-	 * Delegates to {@see \WSUWP\Plugin\Graduate\Factsheet_Team::is_team_member()}
-	 * which also provides backward compatibility with legacy EAM post meta.
-	 *
-	 * @since 1.1.0
-	 * @since 1.3.0 Now delegates to the Factsheet_Team class instead of reading EAM meta directly.
-	 *
-	 * @param int $user_id
-	 * @param int $post_id
-	 *
-	 * @return bool
-	 */
-	public function user_is_eam_user( $user_id, $post_id ) {
-		return \WSUWP\Plugin\Graduate\Factsheet_Team::is_team_member( $user_id, $post_id );
-	}
-
-	/**
-	 * Determines if a user is a restricted contributor.
-	 *
-	 * A user is considered a restricted contributor if:
-	 * - They are assigned as a am to have 2 member, OR
-	 * - They have a WordPress role of 'contributor', 'author', or 'editor' (only 'administrator' has full access)
-	 *
-	 * Restricted users cannot edit (on existing factsheets only):
-	 * - Factsheet title
-	 * - Factsheet display name
-	 * - Include in programs list
-	 * - Program Names taxonomy
-	 * - Degree Types taxonomy
-	 *
-	 * Note: No restrictions apply when creating a NEW factsheet or editing a DRAFT - all fields are editable.
-	 *
-	 * @since 1.4.0
-	 * @since 1.5.0 Added check for new posts and drafts - no restrictions until published.
-	 * @since 1.6.0 Now uses Factsheet_Team for team membership instead of EAM.
-	 *
-	 * @param int      $user_id The user ID to check.
-	 * @param int|null $post_id Optional. The post ID for team membership check.
-	 *
-	 * @return bool True if the user is a restricted contributor, false otherwise.
-	 */
-	public function user_is_restricted_contributor( $user_id, $post_id = null ) {
-		// No restrictions for new posts or drafts - allow full access when creating/drafting a factsheet
-		$post_status = $post_id ? get_post_status( $post_id ) : '';
-		if ( empty( $post_id ) || in_array( $post_status, array( 'auto-draft', 'draft' ), true ) ) {
-			return false;
-		}
-
-		// Check EAM assignment (if post_id provided)
-		if ( $post_id && $this->user_is_eam_user( $user_id, $post_id ) ) {
-			return true;
-		}
-
-		// Check WordPress role
-		$user = new WP_User( $user_id );
-		// Editors, Authors, and Contributors have restricted access to certain fields
-		$restricted_roles = array( 'contributor', 'author', 'editor' );
-		// Only Administrators have full unrestricted access
-		$unrestricted_roles = array( 'administrator' );
-
-		// If user has an unrestricted role, they are not a restricted contributor
-		foreach ( $unrestricted_roles as $role ) {
-			if ( in_array( $role, $user->roles, true ) ) {
-				return false;
-			}
-		}
-
-		// If user has a restricted role, they are a restricted contributor
-		foreach ( $restricted_roles as $role ) {
-			if ( in_array( $role, $user->roles, true ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
-	 * Ensures that restricted contributors are not allowed to change restricted fields.
-	 *
-	 * Restricted contributors include:
-	 * - Users assigned as factsheet team members
-	 * - Users with WordPress contributor or author roles
-	 *
-	 * @since 1.1.0
-	 * @since 1.3.0 Updated to handle multiple restricted fields.
-	 * @since 1.4.0 Updated to use user_is_restricted_contributor() for role-based access.
-	 *
-	 * @param bool   $allowed
-	 * @param string $meta_key
-	 * @param int    $object_id
-	 * @param int    $user_id
-	 *
-	 * @return bool
-	 */
-	public function can_edit_restricted_field( $allowed, $meta_key, $object_id, $user_id ) {
-		if ( $this->user_is_restricted_contributor( $user_id, $object_id ) ) {
-			return false;
-		}
-
-		return $allowed;
-	}
-
-	/**
 	 * Prevents restricted contributors from editing a factsheet's title.
 	 *
 	 * Restricted contributors include:
@@ -1315,7 +1211,7 @@ class WSUWP_Graduate_Degree_Programs {
 	public function manage_factsheet_title_update( $data, $postarr ) {
 		$user = wp_get_current_user();
 
-		if ( isset( $postarr['ID'] ) && $this->user_is_restricted_contributor( $user->ID, $postarr['ID'] ) ) {
+		if ( isset( $postarr['ID'] ) && WSUWP_Factsheet_Access::user_is_restricted_contributor( $user->ID, $postarr['ID'] ) ) {
 			$existing_title = get_post_field( 'post_title', absint( $postarr['ID'] ) );
 			if ( ! empty( $existing_title ) && $data['post_title'] !== $existing_title ) {
 				$data['post_title'] = $existing_title;

--- a/legacy/class-wsuwp-graduate-degree-programs.php
+++ b/legacy/class-wsuwp-graduate-degree-programs.php
@@ -265,7 +265,7 @@ class WSUWP_Graduate_Degree_Programs {
 		$this->factsheet_redirects = new WSUWP_Factsheet_Redirects( $this->post_type_slug, $this->archive_slug );
 		$this->factsheet_archive = new WSUWP_Factsheet_Archive( $this->post_type_slug );
 
-
+		add_filter( 'admin_body_class', array( $this, 'add_factsheet_admin_body_classes' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ) );
 
 		add_action( 'init', array( $this, 'register_post_type' ), 15 );
@@ -317,111 +317,45 @@ class WSUWP_Graduate_Degree_Programs {
 
 			wp_enqueue_script( 'gsdp-factsheet-admin' );
 
-			// Disable title and permalink for restricted contributors (only on published posts, not new/draft ones)
-			$user_id = get_current_user_id();
-			$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$post_status = get_post_status( $post_id );
-			$is_new_or_draft = empty( $post_id ) || in_array( $post_status, array( 'auto-draft', 'draft' ), true );
-
-			// Only apply restrictions when editing published factsheets, not when creating new ones or editing drafts
-			if ( ! $is_new_or_draft && WSUWP_Factsheet_Access::user_is_restricted_contributor( $user_id, $post_id ) ) {
-				// Add inline CSS to visually disable restricted fields
-				$custom_css = '
-					/* Disable title field */
-					#titlewrap input#title {
-						pointer-events: none;
-						background-color: #f0f0f0;
-						color: #666;
-						cursor: not-allowed;
-					}
-					/* Disable permalink edit */
-					#edit-slug-box,
-					#edit-slug-buttons,
-					.edit-slug {
-						pointer-events: none;
-						opacity: 0.5;
-					}
-					#edit-slug-buttons {
-						display: none;
-					}
-					/* Disable Program Names panel (greyed out) */
-					#gs-program-namediv {
-						pointer-events: none;
-						opacity: 0.5;
-					}
-					#gs-program-namediv .inside {
-						background-color: #f0f0f0;
-					}
-					#gs-program-namediv input,
-					#gs-program-namediv select,
-					#gs-program-namediv button {
-						cursor: not-allowed;
-					}
-					/* Disable Degree Types panel (greyed out) */
-					#tagsdiv-gs-degree-type {
-						pointer-events: none;
-						opacity: 0.5;
-					}
-					#tagsdiv-gs-degree-type .inside {
-						background-color: #f0f0f0;
-					}
-					#tagsdiv-gs-degree-type input,
-					#tagsdiv-gs-degree-type select,
-					#tagsdiv-gs-degree-type button {
-						cursor: not-allowed;
-					}
-				';
-				wp_add_inline_style( 'gsdp-admin', $custom_css );
-
-				// Add inline JS to make fields readonly/disabled
-				$custom_js = '
-					jQuery(document).ready(function($) {
-						// Make title readonly
-						$("#title").prop("readonly", true);
-						// Disable permalink edit button
-						$("#edit-slug-buttons .edit-slug").remove();
-						$(".edit-slug").remove();
-						// Disable inputs in Program Names panel
-						$("#gs-program-namediv input, #gs-program-namediv select, #gs-program-namediv button").prop("disabled", true);
-						// Disable inputs in Degree Types panel
-						$("#tagsdiv-gs-degree-type input, #tagsdiv-gs-degree-type select, #tagsdiv-gs-degree-type button").prop("disabled", true);
-					});
-				';
-				wp_add_inline_script( 'gsdp-factsheet-admin', $custom_js );
-			}
-			// Disable Editorial Access Manager (Factsheet Team) panel for non-admins
-			if ( ! current_user_can( 'manage_options' ) ) {
-				$eam_css = '
-					/* Disable EAM / Factsheet Team panel (greyed out) for non-admins */
-					#gsdp-team-members {
-						pointer-events: none;
-						opacity: 0.5;
-					}
-					#gsdp-team-members .inside {
-						background-color: #f0f0f0;
-					}
-					#gsdp-team-members input,
-					#gsdp-team-members select,
-					#gsdp-team-members button {
-						cursor: not-allowed;
-					}
-				';
-				wp_add_inline_style( 'gsdp-admin', $eam_css );
-
-				$eam_js = '
-					jQuery(document).ready(function($) {
-						$("#gsdp-team-members input, #gsdp-team-members select, #gsdp-team-members button").prop("disabled", true);
-					});
-				';
-				wp_add_inline_script( 'gsdp-factsheet-admin', $eam_js );
-			}
 		}
+		
 
 		if ( in_array( $hook_suffix, array( 'edit-tags.php', 'term.php', 'term-new.php' ), true ) && in_array( get_current_screen()->taxonomy, array( 'gs-degree-type' ), true ) ) {
 			wp_enqueue_style( 'gsdp-faculty-admin', WSUWP\Plugin\Graduate\Plugin::get('url'). '/css/faculty-admin.css', array(), WSUWP_Graduate_School_Theme()->theme_version() );
 		}
 	}
+	/**
+	 * Add body classes on factsheet edit screen for conditional admin CSS/JS.
+	 *
+	 * @param string|array $classes Existing body classes (string in older WP, array in WP 5.9+).
+	 * @return string|array
+	 */
+	public function add_factsheet_admin_body_classes( $classes ) {
+		$is_string = is_string( $classes );
+		if ( $is_string ) {
+			$classes = array_filter( array_map( 'trim', explode( ' ', $classes ) ) );
+		}
 
+		$screen = get_current_screen();
+		if ( ! $screen || 'gs-factsheet' !== $screen->id || ! in_array( $screen->base, array( 'post', 'post-new' ), true ) ) {
+			return $is_string ? implode( ' ', $classes ) : $classes;
+		}
+
+		$user_id = get_current_user_id();
+		$post_id = isset( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$post_status = $post_id ? get_post_status( $post_id ) : '';
+		$is_new_or_draft = empty( $post_id ) || in_array( $post_status, array( 'auto-draft', 'draft' ), true );
+
+		if ( ! $is_new_or_draft && WSUWP_Factsheet_Access::user_is_restricted_contributor( $user_id, $post_id ) ) {
+			$classes[] = 'gsdp-restricted-contributor';
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			$classes[] = 'gsdp-eam-disabled';
+		}
+
+		return $is_string ? implode( ' ', $classes ) : $classes;
+	}
 
 	/**
 	 * Register the degree program factsheet post type.

--- a/templates/az-index.php
+++ b/templates/az-index.php
@@ -1,0 +1,291 @@
+
+<!-- <form class="degree-search-wrapper">
+    <label for="degree-search-input" class="visuallyhidden">Search Degrees</label>
+    <input type="text" name="search-degrees" id="degree-search-input" placeholder="Search Degrees A-Z" />
+    <button type="submit">Search</button>
+</form> -->
+
+<div class="degree-list">
+    <div class="toparea">
+        <div class="pagination">
+            <a class="active" href="#a">A</a> <a href="#b">B</a> <a href="#c">C</a> <a href="#d">D</a> <a href="#e">E</a> <a href="#f">F</a> <a href="#g">G</a> <a href="#h">H</a> <a href="#i">I</a> <a href="#j">J</a> <a href="#k">K</a> <a href="#l">L</a> <a href="#m">M</a> <a href="#n">N</a> <a href="#o">O</a> <a href="#p">P</a> <a href="#q">Q</a> <a href="#r">R</a> <a href="#s">S</a> <a href="#t">T</a> <a href="#u">U</a> <a href="#v">V</a> <a href="#w">W</a> <a href="#x">X</a> <a href="#y">Y</a> <a href="#z">Z</a>
+        </div>
+
+        <div class="filter-helper-text">
+            <p>Click on any degree type below to filter the list.</p>
+        </div>
+
+        <div class="key-group">
+            <div class="key-classification">
+                <span>Doctoral Degrees</span>
+                <div class="degree-classification doctorate">D</div>
+            </div>
+
+            <div class="key-classification">
+                <span>Master's Degrees</span>
+                <div class="degree-classification masters">M</div>
+            </div>
+
+            <div class="key-classification">
+                <span>Professional Masters</span>
+                <div class="degree-classification professional-masters">PM</div>
+            </div>
+
+            <div class="key-classification">
+                <span>4+1 Master's Entry</span>
+                <div class="degree-classification masters-4plus1">4+1</div>
+            </div>
+
+            <div class="key-classification">
+                <span>Graduate Certificates</span>
+                <div class="degree-classification graduate-certificate">GC</div>
+            </div>
+
+            <div class="key-classification">
+                <span>Administrator Credentials</span>
+                <div class="degree-classification administrator-credentials">C</div>
+            </div>
+
+        </div>
+    </div>
+
+    <div class="lettergroup">
+        <a id="a" name="a"></a>
+        <div class="bigletter active">A</div>
+        <div class="bigletterline"></div>
+        <ul>
+        <?php
+        $letter = 'a';
+        foreach ( $factsheets as $factsheet_name => $factsheet ) {
+            $factsheet_character = trim( substr( $factsheet_name, 0, 1 ) );
+
+            // Avoid indefinite loops by skipping factsheets that don't start with a-z.
+            if ( ! preg_match( '/^[a-zA-Z]$/', $factsheet_character ) ) {
+                continue;
+            }
+
+            // Output the letter separators between sets of factsheets.
+            while ( 0 !== strcasecmp( $factsheet_character, $letter ) ) {
+                echo '</ul></div>';
+
+                // It's funny and sad, but this works. a becomes b, z becomes aa.
+                $letter++;
+                ?>
+                <div class="lettergroup">
+                    <a id="<?php echo esc_attr( $letter ); ?>" name="<?php echo esc_attr( $letter ); ?>"></a>
+                    <div class="bigletter active"><?php echo strtoupper( $letter ); // @codingStandardsIgnoreLine (This is a controlled letter) ?></div>
+                    <div class="bigletterline"></div>
+                    <ul>
+                <?php
+            }
+
+            if ( 1 < count( $factsheet ) ) {
+                $wrapper_class = 'degree-row-multiple';
+            } else {
+                $wrapper_class = 'degree-row-single';
+            }
+            ?>
+            <li class="degree-row-wrapper <?php echo esc_attr( $wrapper_class ); ?>">
+                <div class="degree-row-top">
+                    <?php
+                    if ( 1 < count( $factsheet ) ) {
+                        ?><div class="degree-name"><span class="degree-caret">▶</span><span class="degree-anchor"><?php echo esc_html( $factsheet_name ); ?></span><?php
+                    } else {
+                        ?><div class="degree-name"><span class="degree-link-icon">🔗</span><a href="<?php echo esc_url( $factsheet[0]['permalink'] ); ?>"><?php echo esc_html( $factsheet_name ); ?></a><?php
+                    }
+                    ?>
+                    </div>
+                    <?php
+                    // Collect all badges first, then sort them
+                    $all_badges = array();
+                    foreach ( $factsheet as $item ) {
+                        // Check if this is a grouped masters degree
+                        if ( isset( $item['degree_classifications'] ) && is_array( $item['degree_classifications'] ) ) {
+                            // Add all classifications from grouped masters
+                            foreach ( $item['degree_classifications'] as $classification ) {
+                                $all_badges[] = $classification;
+                            }
+                        } else {
+                            // Single badge for non-grouped degrees
+                            $all_badges[] = $item['degree_classification'];
+                        }
+                    }
+                    
+                    // Sort badges in the specified order
+                    $badge_order = array(
+                        'doctorate',
+                        'masters',
+                        'professional-masters',
+                        'masters-4plus1',
+                        'graduate-certificate',
+                        'administrator-credentials',
+                    );
+                    
+                    usort( $all_badges, function( $a, $b ) use ( $badge_order ) {
+                        $pos_a = array_search( $a, $badge_order );
+                        $pos_b = array_search( $b, $badge_order );
+                        
+                        // If not found in order array, put at end
+                        if ( false === $pos_a ) {
+                            $pos_a = 999;
+                        }
+                        if ( false === $pos_b ) {
+                            $pos_b = 999;
+                        }
+                        
+                        return $pos_a - $pos_b;
+                    } );
+                    
+                    // Display sorted badges
+                    foreach ( $all_badges as $classification ) {
+                                ?>
+                                <div class="degree-classification <?php echo esc_attr( $classification ); ?>">
+                                    <?php
+                                    // Output the appropriate abbreviation for the degree classification.
+                                    if ( 'graduate-certificate' === $classification ) {
+                                        echo 'GC';
+                                    } elseif ( 'administrator-credentials' === $classification ) {
+                                        echo 'C';
+                                    } elseif ( 'professional-masters' === $classification ) {
+                                        echo 'PM';
+                                    } elseif ( 'masters-4plus1' === $classification ) {
+                                        echo '4+1';
+                                    } elseif ( 'masters' === $classification ) {
+                                        echo 'M';
+                                    } else {
+                                        echo esc_html( $classification[0] );
+                                    }
+                                    ?>
+                                </div>
+                                <?php
+                    }
+                    ?>
+                </div>
+
+                <?php
+                foreach ( $factsheet as $item ) {
+                    // Check if this is a grouped masters degree
+                    if ( isset( $item['degree_classifications'] ) && is_array( $item['degree_classifications'] ) ) {
+                        // Create a single grouped masters row with all badges
+                        // Only render degree-row-bottom if there are multiple factsheets (expandable items)
+                        // For single items, the link is already provided in degree-name, so avoid duplicate links for accessibility
+                        if ( 1 < count( $factsheet ) ) {
+                            ?>
+                            <div class="degree-row-bottom">
+                                <div class="degree-detail">
+                                    <?php
+                                    if ( ! empty( $item['degree_type'] ) ) {
+                                        echo '<a href="' . esc_url( $item['permalink'] ) . '">' . esc_html( $item['degree_type'] ) . '</a>';
+                                    }
+                                    ?>
+                                </div>
+                            <?php
+                            // Sort and display all masters badges
+                            $sorted_classifications = $item['degree_classifications'];
+                            $badge_order = array(
+                                'doctorate',
+                                'masters',
+                                'professional-masters',
+                                'masters-4plus1',
+                                'graduate-certificate',
+                                'administrator-credentials',
+                            );
+                            
+                            usort( $sorted_classifications, function( $a, $b ) use ( $badge_order ) {
+                                $pos_a = array_search( $a, $badge_order );
+                                $pos_b = array_search( $b, $badge_order );
+                                
+                                // If not found in order array, put at end
+                                if ( false === $pos_a ) {
+                                    $pos_a = 999;
+                                }
+                                if ( false === $pos_b ) {
+                                    $pos_b = 999;
+                                }
+                                
+                                return $pos_a - $pos_b;
+                            } );
+                            
+                            foreach ( $sorted_classifications as $classification ) {
+                                ?>
+                                <div class="degree-classification <?php echo esc_attr( $classification ); ?>">
+                                    <?php
+                                    // Output the appropriate abbreviation for the degree classification.
+                                    if ( 'graduate-certificate' === $classification ) {
+                                        echo 'GC';
+                                    } elseif ( 'administrator-credentials' === $classification ) {
+                                        echo 'C';
+                                    } elseif ( 'professional-masters' === $classification ) {
+                                        echo 'PM';
+                                    } elseif ( 'masters-4plus1' === $classification ) {
+                                        echo '4+1';
+                                    } elseif ( 'masters' === $classification ) {
+                                        echo 'M';
+                                    } else {
+                                        echo esc_html( $classification[0] );
+                                    }
+                                    ?>
+                                </div>
+                                <?php
+                            }
+                            ?>
+                            </div>
+                            <?php
+                        }
+                    } else {
+                        // Single degree type for non-grouped degrees
+                        // Only render degree-row-bottom if there are multiple factsheets (expandable items)
+                        // For single items, the link is already provided in degree-name, so avoid duplicate links for accessibility
+                        if ( 1 < count( $factsheet ) ) {
+                            ?>
+                            <div class="degree-row-bottom">
+                                <div class="degree-detail">
+                                    <?php
+                                    if ( ! empty( $item['degree_type'] ) ) {
+                                        echo '<a href="' . esc_url( $item['permalink'] ) . '">' . esc_html( $item['degree_type'] ) . '</a>';
+                                    }
+                                    ?>
+                                </div>
+                                <div class="degree-classification <?php echo esc_attr( $item['degree_classification'] ); ?>">
+                                    <?php
+                                    // Output the appropriate abbreviation for the degree classification.
+                                    if ( 'graduate-certificate' === $item['degree_classification'] ) {
+                                        echo 'GC';
+                                    } elseif ( 'administrator-credentials' === $item['degree_classification'] ) {
+                                        echo 'C';
+                                    } elseif ( 'professional-masters' === $item['degree_classification'] ) {
+                                        echo 'PM';
+                                    } elseif ( 'masters-4plus1' === $item['degree_classification'] ) {
+                                        echo '4+1';
+                                    } else {
+                                        echo esc_html( $item['degree_classification'][0] );
+                                    }
+                                    ?>
+                                </div>
+                            </div>
+                            <?php
+                        }
+                    }
+                }
+                ?>
+            </li>
+            <?php
+        }
+        ?>
+        </ul>
+    </div>
+    <?php
+    $letter++;
+
+    while ( 'aa' !== $letter ) {
+        ?>
+        <div class="lettergroup">
+            <a id="<?php echo esc_attr( $letter ); ?>" name="<?php echo esc_attr( $letter ); ?>"></a>
+            <div class="bigletter active"><?php echo strtoupper( $letter ); // @codingStandardsIgnoreLine (This is a controlled letter) ?></div>
+            <div class="bigletterline"></div>
+        </div>
+        <?php
+        $letter++;
+    }
+    ?>
+</div>

--- a/templates/factsheet.php
+++ b/templates/factsheet.php
@@ -1,0 +1,246 @@
+
+        <div class="factsheet-apply">    
+            <?php if ( ! empty( $factsheet_data['application_url'] ) ) : ?>
+                <a class="wsu-button" href="<?php echo esc_url( $factsheet_data['application_url'] ); ?>">Apply Now</a>
+            <?php endif; ?>
+
+            <?php if (empty( $factsheet_data['application_url'] ) ) : ?>
+                <a class="wsu-button" href="https://gradschool.wsu.edu/apply/">Apply Now</a>
+            <?php endif; ?>   
+        </div>
+
+        <div class="factsheet-statistics-wrapper">
+            <div class="factsheet-stat">
+                <span class="factsheet-label">Program Link:</span>
+                <span class="factsheet-value"><a href="<?php echo esc_url( $factsheet_data['degree_url'] ); ?>"><?php echo esc_html( $factsheet_data['degree_url'] ); ?></a></span>
+            </div>
+            
+            <?php if ( ! empty( $factsheet_data['handbook_url'] ) ) : ?>
+                <div class="factsheet-stat">
+                    <span class="factsheet-label">Program Handbook:</span>
+                    <span class="factsheet-value"><a href="<?php echo esc_url( $factsheet_data['handbook_url'] ); ?>"><?php echo esc_html( $factsheet_data['handbook_url'] ); ?></a></span>
+                </div>
+            <?php endif; ?>
+
+            <?php if ( ! empty( $factsheet_data['student_learning_outcome_url'] ) ) : ?>
+                <div class="factsheet-stat">
+                    <span class="factsheet-label">Student Learning Outcomes:</span>
+                    <span class="factsheet-value"><a href="<?php echo esc_url( $factsheet_data['student_learning_outcome_url'] ); ?>"><?php echo esc_html( $factsheet_data['student_learning_outcome_url'] ); ?></a></span>
+                </div>
+            <?php endif; ?>
+
+            <?php if ( ! empty( $factsheet_data['totalfac'] ) ) : ?>
+
+                <div class="factsheet-stat">
+                    <span class="factsheet-label">Total Graduate Faculty in Program: </span>
+                    <span class="factsheet-value"><?php echo absint( $factsheet_data['totalfac'] ); ?></span>
+                </div>
+
+            <?php endif; ?>
+
+
+            <?php if ( ! empty( $factsheet_data['totalcorefac'] ) ) : ?>
+                <div class="factsheet-stat">
+                <span class="factsheet-label">Total Core Graduate Faculty in Program: </span>
+                <span class="factsheet-value"><?php echo absint( $factsheet_data['totalcorefac'] ); ?></span>
+            </div>
+            <?php endif; ?>
+
+            <?php if ( ! empty( $factsheet_data['students'] ) ) : ?>
+
+                <div class="factsheet-stat">
+                    <span class="factsheet-label">Graduate Students in Program:</span>
+                    <span class="factsheet-value"><?php echo absint( $factsheet_data['students'] ); ?></span>
+                </div>
+           <?php endif; ?>
+
+            <?php if ( !empty( $factsheet_data['aided']) && !empty( $factsheet_data['students']))   : ?>
+
+                <div class="factsheet-stat">
+                    <span class="factsheet-label">Students Receiving Assistantships: </span>
+                    <span class="factsheet-value"><?php echo esc_html( $factsheet_data['aided'] ); ?></span>
+                </div>
+
+            <?php endif; ?>
+
+
+            <div class="factsheet-stat">
+                <span class="factsheet-label">Priority Deadlines:</span>
+                <div class="factsheet-set">
+                    <ul class="wsu-list--style-lined">
+                        <?php
+                        foreach ( $factsheet_data['deadlines'] as $fs_deadline ) {
+                            if ( 'NULL' === $fs_deadline['semester'] || 'None' === $fs_deadline['semester'] ) {
+                                continue;
+                            }
+
+                            if ( in_array( strtolower( $fs_deadline['semester'] ), array( 'summer', 'fall' ), true ) && 'default' === strtolower( $fs_deadline['deadline'] ) ) {
+                                $fs_deadline['deadline'] = 'January 10';
+                            } elseif ( 'spring' === strtolower( $fs_deadline['semester'] ) && 'default' === strtolower( $fs_deadline['deadline'] ) ) {
+                                $fs_deadline['deadline'] = 'July 1';
+                            }
+
+                            $is_date_deadline = explode( '/', $fs_deadline['deadline'] );
+                            if ( 3 === count( $is_date_deadline ) ) {
+                                $date_deadline = strtotime( $fs_deadline['deadline'] );
+                                $fs_deadline['deadline'] = date( 'F j', $date_deadline );
+                            }
+
+                            echo '<li>' . esc_html( $fs_deadline['semester'] ) . ' ' . esc_html( $fs_deadline['deadline'] ) . ' ' . esc_html( $fs_deadline['international'] ) . '</li>';
+                        }
+                        ?>
+                    </ul>
+                </div>
+            </div>
+    
+            <?php if(!empty((($factsheet_data['deadlines_prog'])[0])["deadline"])):?>
+
+            <div class="factsheet-stat">
+                <span class="factsheet-label">Program Deadlines:</span>
+                <div class="factsheet-set">
+                    <ul class="wsu-list--style-lined">
+                        <?php
+                        foreach ( $factsheet_data['deadlines_prog'] as $fs_deadline_prog ) {
+                            if ( 'NULL' === $fs_deadline_prog['semester'] || 'None' === $fs_deadline_prog['semester'] ) {
+                                continue;
+                            }
+
+                            if ( in_array( strtolower( $fs_deadline_prog['semester'] ), array( 'summer', 'fall' ), true ) && 'default' === strtolower( $fs_deadline_prog['deadline'] ) ) {
+                                $fs_deadline_prog['deadline'] = 'January 10';
+                            } elseif ( 'spring' === strtolower( $fs_deadline_prog['semester'] ) && 'default' === strtolower( $fs_deadline_prog['deadline'] ) ) {
+                                $fs_deadline_prog['deadline'] = 'July 1';
+                            }
+
+                            $is_date_deadline = explode( '/', $fs_deadline_prog['deadline'] );
+                            if ( 3 === count( $is_date_deadline ) ) {
+                                $date_deadline = strtotime( $fs_deadline_prog['deadline'] );
+                                $fs_deadline_prog['deadline'] = date( 'F j', $date_deadline );
+                            }
+
+                            echo '<li>' . esc_html( $fs_deadline_prog['semester'] ) . ' ' . esc_html( $fs_deadline_prog['deadline'] ) . ' ' . esc_html( $fs_deadline_prog['international'] ) . '</li>';
+                        }
+                        ?>
+                    </ul>
+                </div>
+            </div>
+
+            <?php endif; ?>
+
+
+            <div class="factsheet-stat">
+                <span class="factsheet-label">Campus:</span>
+                <div class="factsheet-set">
+                    <ul>
+                        <?php
+                        foreach ( $factsheet_data['locations'] as $fs_location => $fs_location_status ) {
+                            if ( 'No' === $fs_location_status || 'By Exception' === $fs_location_status ) 
+                            {
+                                continue;
+                            }
+                            if($fs_location == "Global Campus (online)" and !empty($factsheet_data['global_URL'] ))
+                            {
+                                echo '<li><a target="_blank" href="' . esc_html($factsheet_data['global_URL']) . '">Global Campus (online)</a></li>';
+                            }
+                            else
+                            {
+                                echo '<li>' . esc_html( $fs_location )  . '</li>';
+                            }
+                        }
+                        ?>
+                    </ul>
+                </div>
+            </div>
+
+                <div class="factsheet-stat">
+                    <span class="factsheet-label">International Student English Proficiency Exams</span>
+                    <div class="factsheet-set">
+                   <p class="font-factsheet-label" style="padding-left:25px;">International students may need to surpass the Graduate School's minimum English language proficiency exam scores for this program. If the graduate program has unique score requirements, they will be detailed below. Otherwise, please refer to <a href="https://gradschool.wsu.edu/international-requirements/">the Graduate School's minimum score guidelines. </a></p>
+                    <?php if(!empty((($factsheet_data['requirements'])[0])["score"])):?>
+    
+                        <ul>
+                            <?php
+                            foreach ( $factsheet_data['requirements'] as $fs_requirement ) {
+                                echo '<li>' . esc_html( $fs_requirement['score'] ) . ' ' . esc_html( $fs_requirement['test'] ) . ' ' . esc_html( $fs_requirement['description'] ) . '</li>';
+                            }
+                            ?>
+                        </ul>
+
+                    <?php endif; ?>
+
+                    </div>
+                </div>
+
+
+
+            <?php if(!empty((($factsheet_data['requirements_gre'])[0])["test"])):?>
+                <div class="factsheet-stat">
+                    <span class="factsheet-label">Additional Degree Program Admission Requirements</span>
+                    <div class="factsheet-set">
+                        
+                        <ul>
+                            <?php
+                            foreach ( $factsheet_data['requirements_gre'] as $fs_requirement_gre ) {
+                                echo '<li>' . esc_html( $fs_requirement_gre['test'] ) . ' ' . esc_html( $fs_requirement_gre['required'] ) . '</li>';
+                            }
+                            ?>
+                        </ul>
+                    </div>
+                </div>
+            <?php endif; ?>           
+
+
+       
+        </div>
+
+<div class="wsu-row wsu-row--sidebar-right ">
+
+    <div class="wsu-column">
+        <?php if ( ! empty( $factsheet_data['description'] ) ) : ?>
+            <div class="factsheet-description">
+                <h2>Degree Description:</h2>
+                <?php echo wp_kses_post( apply_filters( 'the_content', $factsheet_data['description'] ) ); ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if ( ! empty( $factsheet_data['admission_requirements'] ) ) : ?>
+            <div class="factsheet-admission-requirements">
+                <h2>Admission Requirements:</h2>
+                <?php echo wp_kses_post( apply_filters( 'the_content', $factsheet_data['admission_requirements'] ) ); ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if ( ! empty( $factsheet_data['student_opportunities'] ) ) : ?>
+            <div class="factsheet-student-opportunities">
+                <h2>Student Opportunities:</h2>
+                <?php echo wp_kses_post( apply_filters( 'the_content', $factsheet_data['student_opportunities'] ) ); ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if ( ! empty( $factsheet_data['career_opportunities'] ) ) : ?>
+            <div class="factsheet-career-opportunities">
+                <h2>Career Opportunities:</h2>
+                <?php echo wp_kses_post( apply_filters( 'the_content', $factsheet_data['career_opportunities'] ) ); ?>
+            </div>
+        <?php endif; ?>
+
+        <?php if ( ! empty( $factsheet_data['career_placements'] ) ) : ?>
+            <div class="factsheet-career-placements">
+                <h2>Career Placements:</h2>
+                <?php echo wp_kses_post( apply_filters( 'the_content', $factsheet_data['career_placements'] ) ); ?>
+            </div>
+        <?php endif; ?>
+        </div>
+    <div class="wsu-column">
+        <h2>Contact Information:</h2>      
+        <ul>
+            <?php
+                    foreach ( $factsheet_data['gscontacts'] as $fs_contact ) {
+                                echo '<li>' . esc_html( $fs_contact['name'] ) . ' <a href="mailto:' . esc_html( $fs_contact['email'] ) .'">'. esc_html( $fs_contact['email'] ). '</a></li>';
+                    }
+            ?>
+        </ul>
+
+    </div>
+</div>
+
+


### PR DESCRIPTION
# Refactor: Extract logic from WSUWP_Graduate_Degree_Programs into focused classes

## Summary
This PR breaks up the large `WSUWP_Graduate_Degree_Programs` legacy class by moving discrete areas of behavior into dedicated classes. The main class keeps wiring (hooks, config, and thin wrappers where needed) and no intentional change in behavior.

---

## Refactor Details

### Refactor 1: Redirects
* **New File:** `legacy/class-factsheet-redirects.php` → `WSUWP_Factsheet_Redirects`
* **Moved:** `redirect_factsheet_id`, `redirect_old_factsheet_urls`, `redirect_private_factsheets`.
* **Constructor:** `( $post_type_slug, $archive_slug )`.
* **Main Class:** Requires the file, instantiates with `$this->post_type_slug` and `$this->archive_slug`, registers `template_redirect` hooks on the instance. Keeps `redirect_factsheet_id( $degree_id )` as a one-line delegate for theme compatibility.

### Refactor 2: Archive, query, menus
* **New File:** `legacy/class-factsheet-archive.php` → `WSUWP_Factsheet_Archive`
* **Moved:** `add_gradfair_query_var`, `register_mirror_menu`, `adjust_factsheet_archive_query`, `filter_factsheet_archive_title`.
* **Constructor:** `( $post_type_slug )`.
* **Main Class:** Requires the file, instantiates, registers the four hooks on the instance.

### Refactor 3: Deprecated filter
* No change in this PR.

### Refactor 4: Public API – get_factsheet_data
* **New File:** `legacy/class-factsheet-data.php` → `WSUWP_Factsheet_Data`
* **Moved:** Full `get_factsheet_data( $post_id )` logic (registered meta, default data, all `gsdp_*` mappings).
* **API:** `WSUWP_Factsheet_Data::get_factsheet_data( $post_id )` (public static).
* **Main Class:** `get_factsheet_data( $post_id )` is a thin wrapper that calls the new class. Callers (`includes/single.php`, `includes/shortcode.php`) continue to use the main class entry point.

### Refactor 5: Permissions / access
* **New File:** `legacy/class-factsheet-access.php` → `WSUWP_Factsheet_Access`
* **Moved:** `user_is_eam_user`, `user_is_restricted_contributor`, `can_edit_restricted_field` (all public static).
* **Main Class:** Auth filters use `array( 'WSUWP_Factsheet_Access', 'can_edit_restricted_field' )`. All permission checks call `WSUWP_Factsheet_Access::*` directly.

### Refactor 6: Admin enqueue
* **New File:** `legacy/class-factsheet-admin-assets.php` → `WSUWP_Factsheet_Admin_Assets`
* **Moved:** `admin_enqueue_scripts( $hook_suffix )`.
* **Note:** Conditional "restricted" and "EAM disabled" styles moved from inline CSS/JS into `css/factsheet-admin.css` and `js/factsheet-admin.min.js`.

### Refactor 7: Sanitization
* **New File:** `legacy/class-factsheet-sanitizer.php` → `WSUWP_Factsheet_Sanitizer`
* **Moved:** `sanitize_gpa`, `sanitize_locations`, `sanitize_deadlines`, `sanitize_contacts`, etc.
* **Fixes:** `sanitize_deadlines` and `sanitize_deadlines_prog` now return cleaned arrays instead of raw input.

### Refactor 8: Field display callbacks
* **New File:** `legacy/class-factsheet-fields-display.php` → `WSUWP_Factsheet_Fields_Display`
* **Moved:** `output_meta_box_html` and all `display_*_meta_field` methods as public static.

---

## File Summary

| New File | Class | Responsibility |
| :--- | :--- | :--- |
| `legacy/class-factsheet-redirects.php` | `WSUWP_Factsheet_Redirects` | Redirects (ID, old URLs, private). |
| `legacy/class-factsheet-archive.php` | `WSUWP_Factsheet_Archive` | Query vars, mirror menu, archive query/title. |
| `legacy/class-factsheet-data.php` | `WSUWP_Factsheet_Data` | `get_factsheet_data()` public API. |
| `legacy/class-factsheet-access.php` | `WSUWP_Factsheet_Access` | Permissions & EAM logic. |
| `legacy/class-factsheet-admin-assets.php` | `WSUWP_Factsheet_Admin_Assets` | Admin CSS/JS enqueue. |
| `legacy/class-factsheet-sanitizer.php` | `WSUWP_Factsheet_Sanitizer` | Meta sanitization. |
| `legacy/class-factsheet-fields-display.php` | `WSUWP_Factsheet_Fields_Display` | Meta box field HTML. |

---

## Testing & Backward Compatibility
* **Testing:** All meta boxes and field types render; save/reload persists data. Restricted contributor logic functions as before.
* **Compatibility:** Theme can still call `WSUWP_Graduate_Degree_Programs()->redirect_factsheet_id( $degree_id )` via the remains delegate. Existing callers of `get_factsheet_data` are unaffected.